### PR TITLE
Implement QueueTaskDispatcher.canRun(Queue.Item)

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -27,79 +27,49 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
     public CauseOfBlockage canTake(Node node, Task task) {
-        if (task instanceof AbstractProject) {
-            AbstractProject<?,?> p = (AbstractProject<?,?>) task;
-            if (task instanceof MatrixConfiguration) {
-                p = (AbstractProject<?,?>)((MatrixConfiguration)task).getParent();
+
+        ThrottleJobProperty tjp = getThrottleJobProperty(task);
+        if (tjp!=null && tjp.getThrottleEnabled()) {
+            CauseOfBlockage cause = canRun(task, tjp);
+            if (cause != null) return cause;
+
+            if (tjp.getMaxConcurrentPerNode().intValue() > 0) {
+                int maxConcurrentPerNode = tjp.getMaxConcurrentPerNode().intValue();
+                int runCount = buildsOfProjectOnNode(node, task);
+
+                // This would mean that there are as many or more builds currently running than are allowed.
+                if (runCount >= maxConcurrentPerNode) {
+                    return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(runCount));
+                }
             }
-            ThrottleJobProperty tjp = p.getProperty(ThrottleJobProperty.class);
 
-            if (tjp!=null && tjp.getThrottleEnabled()) {
-                if (Hudson.getInstance().getQueue().isPending(task)) {
-                    return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
-                }
-                
-                if (tjp.getMaxConcurrentPerNode().intValue() > 0) {
-                    int maxConcurrentPerNode = tjp.getMaxConcurrentPerNode().intValue();
-                    int runCount = buildsOfProjectOnNode(node, task);
-                    
-                    // This would mean that there are as many or more builds currently running than are allowed.
-                    if (runCount >= maxConcurrentPerNode) {
-                        return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(runCount));
-                    }
-                }
-                if (tjp.getMaxConcurrentTotal().intValue() > 0) {
-                    int maxConcurrentTotal = tjp.getMaxConcurrentTotal().intValue();
-                    int totalRunCount = buildsOfProjectOnAllNodes(task);
+            // If the project is in one or more categories...
+            if (tjp.getCategories() != null && !tjp.getCategories().isEmpty()) {
+                for (String catNm : tjp.getCategories()) {
+                    // Quick check that catNm itself is a real string.
+                    if (catNm != null && !catNm.equals("")) {
+                        List<AbstractProject<?,?>> categoryProjects = getCategoryProjects(catNm);
 
-                    if (totalRunCount >= maxConcurrentTotal) {
-                        return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(totalRunCount));
-                    }
-                }
-                // If the project is in one or more categories...
-                if (tjp.getCategories() != null && !tjp.getCategories().isEmpty()) {
-                    for (String catNm : tjp.getCategories()) {
-                        // Quick check that catNm itself is a real string.
-                        if (catNm != null && !catNm.equals("")) {
-                            List<AbstractProject<?,?>> categoryProjects = getCategoryProjects(catNm);
-                            
-                            ThrottleJobProperty.ThrottleCategory category =
-                                ((ThrottleJobProperty.DescriptorImpl)tjp.getDescriptor()).getCategoryByName(catNm);
-                            
-                            // Double check category itself isn't null
-                            if (category != null) {
-                                // Max concurrent per node for category
-                                if (category.getMaxConcurrentPerNode().intValue() > 0) {
-                                    int maxConcurrentPerNode = category.getMaxConcurrentPerNode().intValue();
-                                    int runCount = 0;
-                                    
-                                    for (AbstractProject<?,?> catProj : categoryProjects) {
-                                        if (Hudson.getInstance().getQueue().isPending(catProj)) {
-                                            return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
-                                        }
-                                        runCount += buildsOfProjectOnNode(node, catProj);
+                        ThrottleJobProperty.ThrottleCategory category =
+                            ((ThrottleJobProperty.DescriptorImpl)tjp.getDescriptor()).getCategoryByName(catNm);
+
+                        // Double check category itself isn't null
+                        if (category != null) {
+                            // Max concurrent per node for category
+                            if (category.getMaxConcurrentPerNode().intValue() > 0) {
+                                int maxConcurrentPerNode = category.getMaxConcurrentPerNode().intValue();
+                                int runCount = 0;
+
+                                for (AbstractProject<?,?> catProj : categoryProjects) {
+                                    if (Hudson.getInstance().getQueue().isPending(catProj)) {
+                                        return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
                                     }
-                                    // This would mean that there are as many or more builds currently running than are allowed.
-                                    if (runCount >= maxConcurrentPerNode) {
-                                        return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(runCount));
-                                    }
+                                    runCount += buildsOfProjectOnNode(node, catProj);
                                 }
-                                if (category.getMaxConcurrentTotal().intValue() > 0) {
-                                    int maxConcurrentTotal = category.getMaxConcurrentTotal().intValue();
-                                    int totalRunCount = 0;
-                                    
-                                    for (AbstractProject<?,?> catProj : categoryProjects) {
-                                        if (Hudson.getInstance().getQueue().isPending(catProj)) {
-                                            return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
-                                        }
-                                        totalRunCount += buildsOfProjectOnAllNodes(catProj);
-                                    }
-                                    
-                                    if (totalRunCount >= maxConcurrentTotal) {
-                                        return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(totalRunCount));
-                                    }
+                                // This would mean that there are as many or more builds currently running than are allowed.
+                                if (runCount >= maxConcurrentPerNode) {
+                                    return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(runCount));
                                 }
-                                
                             }
                         }
                     }
@@ -110,6 +80,75 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
+    // @Override on jenkins 4.127+ , but still compatible with 1.399
+    public CauseOfBlockage canRun(Queue.Item item) {
+        ThrottleJobProperty tjp = getThrottleJobProperty(item.task);
+        if (tjp!=null && tjp.getThrottleEnabled()) {
+            return canRun(item.task, tjp);
+        }
+        return null;
+    }
+
+    public CauseOfBlockage canRun(Task task, ThrottleJobProperty tjp) {
+        if (Hudson.getInstance().getQueue().isPending(task)) {
+            return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
+        }
+        if (tjp.getMaxConcurrentTotal().intValue() > 0) {
+            int maxConcurrentTotal = tjp.getMaxConcurrentTotal().intValue();
+            int totalRunCount = buildsOfProjectOnAllNodes(task);
+
+            if (totalRunCount >= maxConcurrentTotal) {
+                return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(totalRunCount));
+            }
+        }
+        // If the project is in one or more categories...
+        if (tjp.getCategories() != null && !tjp.getCategories().isEmpty()) {
+            for (String catNm : tjp.getCategories()) {
+                // Quick check that catNm itself is a real string.
+                if (catNm != null && !catNm.equals("")) {
+                    List<AbstractProject<?,?>> categoryProjects = getCategoryProjects(catNm);
+
+                    ThrottleJobProperty.ThrottleCategory category =
+                            ((ThrottleJobProperty.DescriptorImpl)tjp.getDescriptor()).getCategoryByName(catNm);
+
+                    // Double check category itself isn't null
+                    if (category != null) {
+                        if (category.getMaxConcurrentTotal().intValue() > 0) {
+                            int maxConcurrentTotal = category.getMaxConcurrentTotal().intValue();
+                            int totalRunCount = 0;
+
+                            for (AbstractProject<?,?> catProj : categoryProjects) {
+                                if (Hudson.getInstance().getQueue().isPending(catProj)) {
+                                    return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
+                                }
+                                totalRunCount += buildsOfProjectOnAllNodes(catProj);
+                            }
+
+                            if (totalRunCount >= maxConcurrentTotal) {
+                                return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(totalRunCount));
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+
+    private ThrottleJobProperty getThrottleJobProperty(Task task) {
+        if (task instanceof AbstractProject) {
+            AbstractProject<?,?> p = (AbstractProject<?,?>) task;
+            if (task instanceof MatrixConfiguration) {
+                p = (AbstractProject<?,?>)((MatrixConfiguration)task).getParent();
+            }
+            ThrottleJobProperty tjp = p.getProperty(ThrottleJobProperty.class);
+            return tjp;
+        }
+        return null;
+    }
     
     private int buildsOfProjectOnNode(Node node, Task task) {
         int runCount = 0;


### PR DESCRIPTION
Split the canTake logic in two methods so that the plugin can override canRun on jenkins 1.427 for finer Queue management, but still be compatible with 1.399
