### PR TITLE
Categories optionally configured with pairs of throttled node labels.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 *.iws
 target
 work
+# eclipse =>
+.classpath
+.project
+.settings
+bin

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -3,7 +3,6 @@ package hudson.plugins.throttleconcurrents;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
-import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Computer;
 import hudson.model.Executor;
@@ -11,16 +10,14 @@ import hudson.model.Hudson;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.model.Queue.Task;
+import hudson.model.labels.LabelAtom;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
+import java.util.Set;
 import java.util.logging.Logger;
-
 
 @Extension
 public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
@@ -61,10 +58,10 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                             // Double check category itself isn't null
                             if (category != null) {
                                 // Max concurrent per node for category
-                                if (category.getMaxConcurrentPerNode().intValue() > 0) {
-                                    int maxConcurrentPerNode = category.getMaxConcurrentPerNode().intValue();
+                                int maxConcurrentPerNode = getMaxConcurrentPerNodeBasedOnMatchingLabels(
+                                    node, category, category.getMaxConcurrentPerNode().intValue());
+                                if (maxConcurrentPerNode > 0) {
                                     int runCount = 0;
-
                                     for (AbstractProject<?,?> catProj : categoryProjects) {
                                         if (Hudson.getInstance().getQueue().isPending(catProj)) {
                                             return CauseOfBlockage.fromMessage(Messages._ThrottleQueueTaskDispatcher_BuildPending());
@@ -150,7 +147,6 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         return null;
     }
 
-
     private ThrottleJobProperty getThrottleJobProperty(Task task) {
         if (task instanceof AbstractProject) {
             AbstractProject<?,?> p = (AbstractProject<?,?>) task;
@@ -203,7 +199,6 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         return runCount;
     }
 
-
     private List<AbstractProject<?,?>> getCategoryProjects(String category) {
         List<AbstractProject<?,?>> categoryProjects = new ArrayList<AbstractProject<?,?>>();
 
@@ -222,6 +217,41 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         return categoryProjects;
     }
 
-    private static final Logger LOGGER = Logger.getLogger(ThrottleQueueTaskDispatcher.class.getName());
+    /**
+     * @param node to compare labels with.
+     * @param category to compare labels with.
+     * @param maxConcurrentPerNode to return if node labels mismatch.
+     * @return maximum concurrent number of builds per node based on matching labels, as an int.
+     * @author marco.miller@ericsson.com
+     */
+    private int getMaxConcurrentPerNodeBasedOnMatchingLabels(
+        Node node, ThrottleJobProperty.ThrottleCategory category, int maxConcurrentPerNode)
+    {
+        List<ThrottleJobProperty.NodeLabeledPair> nodeLabeledPairs = category.getNodeLabeledPairs();
+        int maxConcurrentPerNodeLabeledIfMatch = maxConcurrentPerNode;
+        boolean nodeLabelsMatch = false;
+        Set<LabelAtom> nodeLabels = node.getAssignedLabels();
 
+        for(ThrottleJobProperty.NodeLabeledPair nodeLabeledPair: nodeLabeledPairs) {
+            String throttledNodeLabel = nodeLabeledPair.getThrottledNodeLabel();
+            if(!nodeLabelsMatch && !throttledNodeLabel.isEmpty()) {
+                for(LabelAtom aNodeLabel: nodeLabels) {
+                    String nodeLabel = aNodeLabel.getDisplayName();
+                    if(nodeLabel.equals(throttledNodeLabel)) {
+                        maxConcurrentPerNodeLabeledIfMatch = nodeLabeledPair.getMaxConcurrentPerNodeLabeled().intValue();
+                        LOGGER.fine("node labels match");
+                        LOGGER.fine("=> maxConcurrentPerNode' = "+maxConcurrentPerNodeLabeledIfMatch);
+                        nodeLabelsMatch = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if(!nodeLabelsMatch) {
+            LOGGER.fine("node labels mismatch");
+        }
+        return maxConcurrentPerNodeLabeledIfMatch;
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(ThrottleQueueTaskDispatcher.class.getName());
 }

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/global.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/global.jelly
@@ -2,43 +2,35 @@
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="Throttle Concurrent Builds">
     <f:entry title="Multi-Project Throttle Categories" field="categories">
-      <f:repeatable field="categories" minimum="0">
+      <f:repeatable field="categories" add="${%Add Category}" minimum="0">
         <table width="100%">
           <f:entry title="Category Name" field="categoryName">
             <f:textbox />
           </f:entry>
-          <f:entry title="${%Maximum Total Concurrent Builds}" field="maxConcurrentTotal"
-                   help="${descriptor.getHelpFile('maxConcurrentTotal')}">
-            <f:textbox />
-          </f:entry>
-          <f:entry title="${%Maximum Concurrent Builds Per Node}" field="maxConcurrentPerNode">
-            <f:textbox />
-          </f:entry>
-        </table>
-        <div align="right">
-          <f:repeatableDeleteButton/>
-        </div>
-      </f:repeatable> 
-<!--      <f:repeatable var="category" varStatus="loopStatus" items="${descriptor.categories}" minimum="0">
-        <table width="100%">
-          <f:entry title="Category Name">
-            <f:textbox name="throttle.categories.categoryName" value="${category.categoryName}"/>
-          </f:entry>
           <f:entry title="${%Maximum Total Concurrent Builds}" field="maxConcurrentTotal">
-            <f:textbox name="throttle.categories.maxConcurrentTotal"
-                       value="${category.maxConcurrentTotal}"
-                       checkUrl="${descriptor.getCheckUrl('maxConcurrentTotal')}" />
+            <f:textbox />
           </f:entry>
           <f:entry title="${%Maximum Concurrent Builds Per Node}" field="maxConcurrentPerNode">
-            <f:textbox name="throttle.categories.maxConcurrentPerNode"
-                       value="${category.maxConcurrentPerNode}"
-                       checkUrl="${descriptor.getCheckUrl('maxConcurrentPerNode')}" />
+            <f:textbox />
           </f:entry>
         </table>
+        <f:repeatable field="nodeLabeledPairs" add="${%Add Maximum Per Labeled Node}" minimum="0" header="${%Maximum Per Labeled Node}">
+          <table width="100%">
+            <f:entry title="${%Throttled Node Label}" field="throttledNodeLabel">
+              <f:textbox />
+            </f:entry>
+            <f:entry title="${%Maximum Concurrent Builds Per Node Labeled As Above}" field="maxConcurrentPerNodeLabeled">
+              <f:textbox />
+            </f:entry>
+          </table>
+          <div align="right">
+            <f:repeatableDeleteButton/>
+          </div>
+        </f:repeatable>
         <div align="right">
           <f:repeatableDeleteButton/>
         </div>
-      </f:repeatable> -->
+      </f:repeatable>
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-categories.html
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-categories.html
@@ -1,3 +1,7 @@
 <div>
   <p>Categories can be used to throttle multiple projects.</p>
+  <p>Categories can be optionally configured with pairs of throttled Jenkins node labels.<br>
+     Pairs can make each maximum applicable to nodes with matching labels only.<br>
+     That is achieved by adding such Maximum Per Labeled Node pair(s) to any category.<br>
+     Category's Maximum Concurrent Builds Per Node is superseded by matching-pair's maximum.</p>
 </div>

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
@@ -1,0 +1,62 @@
+/**
+ * MIT License
+ * Copyright (c) 2013, Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package hudson.plugins.throttleconcurrents;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * This class initiates the testing of {@link hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory}.<br>
+ * -Hence this class also testing {@link hudson.plugins.throttleconcurrents.ThrottleJobProperty.NodeLabeledPair}.<br>
+ * -Test methods for {@link hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory#getNodeLabeledPairs()}.
+ * @author marco.miller@ericsson.com
+ */
+public class ThrottleCategoryTest
+{
+    private static final String testCategoryName = "aCategory";
+
+    @Test
+    public void shouldGetEmptyNodeLabeledPairsListUponInitialNull()
+    {
+        ThrottleJobProperty.ThrottleCategory category =
+            new ThrottleJobProperty.ThrottleCategory(testCategoryName, 0, 0, null);
+        assertTrue("nodeLabeledPairs shall be empty", category.getNodeLabeledPairs().isEmpty());
+    }
+
+    @Test
+    public void shouldGetNonEmptyNodeLabeledPairsListThatWasSet()
+    {
+        String expectedLabel = "aLabel";
+        Integer expectedMax = new Integer(1);
+
+        ThrottleJobProperty.ThrottleCategory category =
+            new ThrottleJobProperty.ThrottleCategory(testCategoryName, 0, 0, null);
+        List<ThrottleJobProperty.NodeLabeledPair> nodeLabeledPairs = category.getNodeLabeledPairs();
+        nodeLabeledPairs.add(new ThrottleJobProperty.NodeLabeledPair(expectedLabel, expectedMax));
+
+        String actualLabel = category.getNodeLabeledPairs().get(0).getThrottledNodeLabel();
+        Integer actualMax = category.getNodeLabeledPairs().get(0).getMaxConcurrentPerNodeLabeled();
+
+        assertEquals("throttledNodeLabel "+actualLabel+" does not match expected "+expectedLabel,
+            expectedLabel, actualLabel);
+        assertEquals("maxConcurrentPerNodeLabeled "+actualMax+" does not match expected "+expectedMax,
+            expectedMax, actualMax);
+    }
+}

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -1,0 +1,409 @@
+/**
+ * MIT License
+ * Copyright (c) 2013, Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+ * OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package hudson.plugins.throttleconcurrents;
+
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlOption;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlRadioButtonInput;
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+
+import hudson.model.FreeStyleProject;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.jvnet.hudson.test.HudsonTestCase;
+
+/**
+ * This class initiates the testing of {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher}.<br>
+ * -Test methods for {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher#canTake(hudson.model.Node, hudson.model.Queue.Task)}.<br>
+ * -Happens to test {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher#getMaxConcurrentPerNodeBasedOnMatchingLabels(hudson.model.Node, hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory, int)}.
+ * @author marco.miller@ericsson.com
+ */
+public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
+{
+    private static final String buttonsXPath = "//button[@tabindex='0']";
+    private static final String configFormName = "config";
+    private static final String configUrlSuffix = "configure";
+    private static final String logUrlPrefix = "log/";
+    private static final String match = "match";
+    private static final String matchTrace = "node labels match";
+    private static final String max = "max";
+    private static final String maxTrace = "=> maxConcurrentPerNode' = ";
+    private static final String mismatch = "mismatch";
+    private static final String mismatchTrace = "node labels mismatch";
+    private static final String parentXPath = "//td[contains(text(),'Throttl')]/..";
+    private static final String saveButtonText = "Save";
+    private static final String testCategoryName = "cat1";
+    private static final String testCategoryLabel = testCategoryName+"label";
+    //
+    private static final boolean configureNodeLabel = true;
+    private static final boolean configureNoNodeLabel = false;
+    private static final boolean expectMatch = true;
+    private static final boolean expectMismatch = false;
+    //
+    private static final int configureOneMaxLabelPair = 1;
+    private static final int configureTwoMaxLabelPairs = 2;
+    private static final int noCategoryWideMaxConcurrentPerNode = 0;
+    private static final int someCategoryWideMaxConcurrentPerNode = 1;
+    private static final int greaterCategoryWideMaxConcurrentPerNode = configureOneMaxLabelPair+1;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    /**
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPair()
+    throws ExecutionException, InterruptedException, IOException
+    {
+        assertBasedOnMaxLabelPairMatchingOrNot(
+            configureOneMaxLabelPair,
+            noCategoryWideMaxConcurrentPerNode,
+            expectMatch,
+            configureNodeLabel);
+    }
+
+    /**
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPairs()
+    throws ExecutionException, InterruptedException, IOException
+    {
+        assertBasedOnMaxLabelPairMatchingOrNot(
+            configureTwoMaxLabelPairs,
+            noCategoryWideMaxConcurrentPerNode,
+            expectMatch,
+            configureNodeLabel);
+    }
+
+    /**
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    public void testShouldConsiderTaskAsBlockableStillUponMatchingLabelPairWithLowestMax()
+    throws ExecutionException, InterruptedException, IOException
+    {
+        assertBasedOnMaxLabelPairMatchingOrNot(
+            configureOneMaxLabelPair, //=> label-pair max of 1, still to match as *the* max;
+            greaterCategoryWideMaxConcurrentPerNode, //greater than label-pair max but still
+            expectMatch,
+            configureNodeLabel);
+    }
+
+    /**
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    public void testShouldConsiderTaskAsBuildableStillUponMismatchingMaxLabelPairs()
+    throws ExecutionException, InterruptedException, IOException
+    {
+        assertBasedOnMaxLabelPairMatchingOrNot(
+            configureTwoMaxLabelPairs,
+            someCategoryWideMaxConcurrentPerNode,
+            expectMismatch,
+            configureNodeLabel);
+    }
+
+    /**
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    public void testShouldConsiderTaskAsBuildableStillUponNoNodeLabel()
+    throws ExecutionException, InterruptedException, IOException
+    {
+        assertBasedOnMaxLabelPairMatchingOrNot(
+            configureOneMaxLabelPair,
+            someCategoryWideMaxConcurrentPerNode,
+            expectMismatch,
+            configureNoNodeLabel);
+    }
+
+    /**
+     * @param targetedPairNumber of throttling category maximum/label pairs.
+     * @param maxConcurrentPerNode or category-wide maximum.
+     * @param expectMatch of labels (or not).
+     * @param configureNodeLabel or not.
+     * @throws ExecutionException upon Jenkins project build scheduling issue.
+     * @throws InterruptedException upon Jenkins global configuration issue.
+     * @throws IOException upon many potential Jenkins IO issues during test.
+     */
+    private void assertBasedOnMaxLabelPairMatchingOrNot(
+        int targetedPairNumber, int maxConcurrentPerNode, boolean expectMatch, boolean configureNodeLabel)
+    throws ExecutionException, InterruptedException, IOException
+    {
+        if(configureNodeLabel)
+        {
+            String nodeLabelSuffix = expectMatch ? "" : "other";
+            configureNewNodeWithLabel(testCategoryLabel +targetedPairNumber +nodeLabelSuffix);
+        }
+        configureGlobalThrottling(testCategoryLabel, targetedPairNumber, maxConcurrentPerNode);
+
+        FreeStyleProject project = createFreeStyleProject();
+        configureJobThrottling(project);
+        String logger = configureLogger();
+        project.scheduleBuild2(0).get();
+        HtmlPage page = getLoggerPage(logger);
+        if(expectMatch)
+        {
+            assertTrue(expectedTracesMessage(match, true), page.asText().contains(matchTrace));
+            assertTrue(expectedTracesMessage(max, true), page.asText().contains(maxTrace+targetedPairNumber));
+        }
+        else {
+            assertTrue(expectedTracesMessage(mismatch, true), page.asText().contains(mismatchTrace));
+            assertFalse(expectedTracesMessage(max, false), page.asText().contains(maxTrace));
+        }
+    }
+
+    private void configureGlobalThrottling(String labelRoot, int numberOfPairs, int maxConcurrentPerNode)
+    throws InterruptedException, IOException, MalformedURLException
+    {
+        URL url = new URL(getURL()+configUrlSuffix);
+        HtmlPage page = createWebClient().getPage(url);
+        HtmlForm form = page.getFormByName(configFormName);
+        List<HtmlButton> buttons = form.getByXPath(parentXPath+buttonsXPath);
+        String buttonText = "Add Category";
+        boolean buttonFound = false;
+
+        for(HtmlButton button: buttons) {
+            if(button.getTextContent().equals(buttonText))
+            {
+                buttonFound = true;
+                button.click();
+
+                HtmlInput input = form.getInputByName("_.categoryName");
+                input.setValueAttribute(testCategoryName);
+                //_.maxConcurrentTotal ignored.
+                input = form.getInputByName("_.maxConcurrentPerNode");
+                input.setValueAttribute(""+maxConcurrentPerNode);
+
+                buttons = form.getByXPath(parentXPath+buttonsXPath);
+                buttonText = "Add Maximum Per Labeled Node";
+                buttonFound = false;
+                for(HtmlButton deeperButton: buttons) {
+                    if(deeperButton.getTextContent().equals(buttonText))
+                    {
+                        buttonFound = true;
+                        for(int i=0; i<numberOfPairs; i++)
+                        {
+                            List<HtmlInput> inputs = null;
+                            int clickThenWaitForMaxTries = 3;
+                            do {
+                                page = (HtmlPage)deeperButton.click();
+                                TimeUnit.SECONDS.sleep(1);
+                                form = page.getFormByName(configFormName);
+                                inputs = form.getInputsByName("_.throttledNodeLabel");
+                                clickThenWaitForMaxTries--;
+                            } while(inputs.isEmpty() && clickThenWaitForMaxTries > 0);
+
+                            assertFalse(buttonText+" button clicked; no resulting field found on "+url, inputs.isEmpty());
+                            inputs.get(i).setValueAttribute(labelRoot+(i+1));
+
+                            inputs = form.getInputsByName("_.maxConcurrentPerNodeLabeled");
+                            inputs.get(i).setValueAttribute(""+(i+1));
+                        }
+                    }
+                }
+                failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+                break;
+            }
+        }
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+
+        buttons = form.getByXPath(buttonsXPath);
+        buttonText = saveButtonText;
+        buttonFound = buttonFoundThusFormSubmitted(form, buttons, buttonText);
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+    }
+
+    private void configureJobThrottling(FreeStyleProject project)
+    throws IOException, MalformedURLException
+    {
+        URL url = new URL(getURL()+project.getUrl()+configUrlSuffix);
+        HtmlPage page = createWebClient().getPage(url);
+        HtmlForm form = page.getFormByName(configFormName);
+        List<HtmlButton> buttons = form.getByXPath(buttonsXPath);
+        String buttonText = saveButtonText;
+        boolean buttonFound = false;
+
+        for(HtmlButton button: buttons) {
+            if(button.getTextContent().equals(buttonText))
+            {
+                buttonFound = true;
+                String checkboxName = "throttleEnabled";
+                HtmlElement checkbox = page.getElementByName(checkboxName);
+                assertNotNull(checkboxName+" checkbox not found on test job config page; plugin installed?", checkbox);
+                checkbox.click();
+
+                List<HtmlRadioButtonInput> radios = form.getRadioButtonsByName("throttleOption");
+                for(HtmlRadioButtonInput radio: radios) {
+                    radio.setChecked(radio.getValueAttribute().equals("category"));
+                }
+                checkbox = page.getElementByName("categories");
+                checkbox.click();
+
+                form.submit(button);
+                break;
+            }
+        }
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+    }
+
+    private void configureNewNodeWithLabel(String label)
+    throws IOException, MalformedURLException
+    {
+        URL url = new URL(getURL()+"computer/new");
+        HtmlPage page = createWebClient().getPage(url);
+        HtmlForm form = page.getFormByName("createItem");
+
+        HtmlInput input = form.getInputByName("name");
+        input.setValueAttribute("test");
+
+        List<HtmlRadioButtonInput> radios = form.getRadioButtonsByName("mode");
+        for(HtmlRadioButtonInput radio: radios) {
+            radio.setChecked(radio.getValueAttribute().equals("hudson.slaves.DumbSlave"));
+        }
+        List<HtmlButton> buttons = form.getByXPath(buttonsXPath);
+        String buttonText = "OK";
+        boolean buttonFound = false;
+
+        for(HtmlButton button: buttons) {
+            if(button.getTextContent().equals(buttonText))
+            {
+                buttonFound = true;
+                page = (HtmlPage)form.submit(button);
+                List<HtmlForm> forms = page.getForms();
+
+                for(HtmlForm aForm: forms) {
+                    if(aForm.getActionAttribute().equals("doCreateItem"))
+                    {
+                        form = aForm;
+                        break;
+                    }
+                }
+                input = form.getInputByName("_.numExecutors");
+                input.setValueAttribute("1");
+
+                input = form.getInputByName("_.remoteFS");
+                input.setValueAttribute("/");
+
+                input = form.getInputByName("_.labelString");
+                input.setValueAttribute(label);
+                break;
+            }
+        }
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+
+        buttons = form.getByXPath(buttonsXPath);
+        buttonText = saveButtonText;
+        buttonFound = buttonFoundThusFormSubmitted(form, buttons, buttonText);
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+    }
+
+    private String configureLogger()
+    throws IOException, MalformedURLException
+    {
+        String logger = ThrottleQueueTaskDispatcher.class.getName();
+        jenkins.getLog().doNewLogRecorder(logger);
+        URL url = new URL(getURL()+logUrlPrefix+logger+"/"+configUrlSuffix);
+        HtmlPage page = createWebClient().getPage(url);
+        HtmlForm form = page.getFormByName(configFormName);
+        List<HtmlButton> buttons = form.getByXPath(buttonsXPath);
+        String buttonText = "Add";
+        boolean buttonFound = false;
+
+        for(HtmlButton button: buttons) {
+            if(button.getTextContent().equals(buttonText))
+            {
+                buttonFound = true;
+                button.click();
+
+                List<HtmlInput> inputs = form.getInputsByName("_.name");
+                for(HtmlInput input: inputs) {
+                    input.setValueAttribute(logger);
+                }
+                HtmlSelect select = form.getSelectByName("level");
+                HtmlOption option = select.getOptionByValue("fine");
+                select.setSelectedAttribute(option, true);
+                break;
+            }
+        }
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+
+        buttonText = saveButtonText;
+        buttonFound = buttonFoundThusFormSubmitted(form, buttons, buttonText);
+        failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
+        return logger;
+    }
+
+    private boolean buttonFoundThusFormSubmitted(HtmlForm form, List<HtmlButton> buttons, String buttonText)
+    throws IOException
+    {
+        boolean buttonFound = false;
+        for(HtmlButton button: buttons) {
+            if(button.getTextContent().equals(buttonText))
+            {
+                buttonFound = true;
+                form.submit(button);
+                break;
+            }
+        }
+        return buttonFound;
+    }
+
+    private String expectedTracesMessage(String traceKind, boolean assertingTrue)
+    {
+        StringBuffer messagePrefix = new StringBuffer("log shall");
+        if(!assertingTrue) {
+            messagePrefix.append(" not");
+        }
+        return messagePrefix+" contain '"+traceKind+"' traces";
+    }
+
+    private void failWithMessageIfButtonNotFoundOnPage(boolean buttonFound, String buttonText, URL url)
+    {
+        assertTrue(buttonText+" button not found on "+url, buttonFound);
+    }
+
+    private HtmlPage getLoggerPage(String logger)
+    throws IOException, MalformedURLException
+    {
+        URL url = new URL(getURL()+logUrlPrefix+logger);
+        return createWebClient().getPage(url);
+    }
+}


### PR DESCRIPTION
JENKINS-19645
Pairs make each maximum applicable to nodes with matching labels only.
-Achieved by adding such Maximum Per Labeled Node pairs to categories.
Category's Maximum Concurrent Builds Per Node is superseded if matching.
