### PR TITLE
[FIXED JENKINS-21044] - Throttling blocks the Jenkins queue

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -174,9 +174,12 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
             super(ThrottleJobProperty.class);
             synchronized(propertiesByCategoryLock) {
                 load();
-                // Explictly drop queue items loaded from 1.8.1 version
-                if (!propertiesByCategory.isEmpty()) {
+                // Explictly handle the persisted data from the version 1.8.1
+                if (propertiesByCategory == null) {
                     propertiesByCategory = new HashMap<String,Map<ThrottleJobProperty,Void>>();
+                }
+                if (!propertiesByCategory.isEmpty()) {
+                    propertiesByCategory.clear();
                     save(); // Save the configuration to remove obsolete data
                 }
             }


### PR DESCRIPTION
Seems the issue was in improper usage of WeakHashMap (see analysis from @centic).
I've managed to reproduce the behavior in the following case:
- There is a big number of jobs/configurations with throttling
- The builds queue is not empty
  // Seems that ThrottleQueueTaskDispatcher tries to access the data before the complete loading of the plugin's configuration.

This fix provides an explicit locking of any load operations + manual cleanup of erroneous cache data, which goes to persistence in 1.8.1
Resolves https://issues.jenkins-ci.org/browse/JENKINS-21044

Signed-off-by: Oleg Nenashev o.v.nenashev@gmail.com
