### PR TITLE
Adding support for Throttle configurations optionally in matrix jobs

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -24,11 +24,13 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
     public CauseOfBlockage canTake(Node node, Task task) {
-        if (task instanceof MatrixConfiguration) {
+
+        ThrottleJobProperty tjp = getThrottleJobProperty(task);
+
+        if (task instanceof MatrixConfiguration &&  !tjp.getThrottleConfiguration()){
             return null;
         }
 
-        ThrottleJobProperty tjp = getThrottleJobProperty(task);
         if (tjp!=null && tjp.getThrottleEnabled()) {
             CauseOfBlockage cause = canRun(task, tjp);
             if (cause != null) return cause;
@@ -93,7 +95,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     }
 
     public CauseOfBlockage canRun(Task task, ThrottleJobProperty tjp) {
-        if (task instanceof MatrixConfiguration) {
+        if (task instanceof MatrixConfiguration &&  !tjp.getThrottleConfiguration()){
             return null;
         }
         if (Hudson.getInstance().getQueue().isPending(task)) {
@@ -170,7 +172,8 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
             for (Executor e : computer.getExecutors()) {
                 runCount += buildsOnExecutor(task, e);
             }
-            if (task instanceof MatrixProject) {
+            ThrottleJobProperty tjp = getThrottleJobProperty(task);
+            if (task instanceof MatrixConfiguration &&  !tjp.getThrottleConfiguration()){
                 for (Executor e : computer.getOneOffExecutors()) {
                     runCount += buildsOnExecutor(task, e);
                 }

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -29,7 +29,8 @@
         </j:forEach>
       </f:entry>
     </j:if>
+    <f:entry title="${%Throttle the configurations of this Matrix Project instead of the Parent Project}" field="throttleConfiguration" >
+        <f:checkbox/>
+    </f:entry>
   </f:optionalBlock>
 </j:jelly>
-    
-      

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -21,11 +21,11 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names
         FreeStyleProject p1 = createFreeStyleProject("p1");
         FreeStyleProject p2 = createFreeStyleProject("p2");
-        p2.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha), false, THROTTLE_OPTION_CATEGORY));
+        p2.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha), false, THROTTLE_OPTION_CATEGORY, false));
         FreeStyleProject p3 = createFreeStyleProject("p3");
-        p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY));
+        p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY, false));
         FreeStyleProject p4 = createFreeStyleProject("p4");
-        p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY));
+        p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY, false));
         // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we can check jobs inside folders
         assertProjects(alpha, p3);
         assertProjects(beta, p3, p4);
@@ -61,6 +61,4 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
             return super.getACL(project);
         }
     }
-
-
 }


### PR DESCRIPTION
I had added an option so in Matrix jobs you can select whether the throttling it's done at parent or configuration level.

This is a replacement for pull request #11
