### PR TITLE
JENKINS-23368 - Enforce start interval/delay between running builds.

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -39,6 +39,7 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
     
     private Integer maxConcurrentPerNode;
     private Integer maxConcurrentTotal;
+    private Long startInterval;
     private List<String> categories;
     private boolean throttleEnabled;
     private String throttleOption;
@@ -57,10 +58,12 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
                                List<String> categories,
                                boolean throttleEnabled,
                                String throttleOption,
-                               @CheckForNull ThrottleMatrixProjectOptions matrixOptions
+                               @CheckForNull ThrottleMatrixProjectOptions matrixOptions,
+                               Long startInterval
                                ) {
         this.maxConcurrentPerNode = maxConcurrentPerNode == null ? 0 : maxConcurrentPerNode;
         this.maxConcurrentTotal = maxConcurrentTotal == null ? 0 : maxConcurrentTotal;
+        this.startInterval = startInterval == null ? 0L : startInterval;
         this.categories = categories;
         this.throttleEnabled = throttleEnabled;
         this.throttleOption = throttleOption;
@@ -100,6 +103,10 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
             matrixOptions = new ThrottleMatrixProjectOptions(false, true);
         }
         
+        if (startInterval == null) {
+            startInterval = 0L;
+        }
+          
         return this;
     }
 
@@ -144,6 +151,13 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
             maxConcurrentTotal = 0;
         
         return maxConcurrentTotal;
+    }
+
+    public Long getStartInterval() {
+        if (startInterval == null) 
+            startInterval = 0L;
+
+        return startInterval;
     }
 
     @CheckForNull
@@ -276,6 +290,9 @@ public class ThrottleJobProperty extends JobProperty<AbstractProject<?,?>> {
             return checkNullOrInt(value);
         }
 
+        public FormValidation doCheckStartInterval(@QueryParameter String value) {
+            return checkNullOrInt(value);
+        }
         
         public ThrottleCategory getCategoryByName(String categoryName) {
             ThrottleCategory category = null;

--- a/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
@@ -1,5 +1,5 @@
 ThrottleQueueTaskDispatcher.MaxCapacityOnNode=Already running {0} builds on node
 ThrottleQueueTaskDispatcher.MaxCapacityTotal=Already running {0} builds across all nodes
 ThrottleQueueTaskDispatcher.BuildPending=A build is pending launch
-
+ThrottleQueueTaskDispatcher.StartIntervalLimit=Waiting for required start interval. [{0}m {1}s]
 ThrottleMatrixProjectOptions.DisplayName=Additional options for Matrix projects

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -20,6 +20,10 @@
              field="maxConcurrentPerNode">
       <f:textbox />
     </f:entry>
+    <f:entry title="${%Minimum Start Interval between Builds in seconds}"
+             field="startInterval">
+      <f:textbox />
+    </f:entry>
     <j:if test="${!empty(descriptor.categories)}">
       <f:entry title="${%Multi-Project Throttle Category}">
         <j:forEach var="cat" items="${descriptor.categories}">

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -21,11 +21,11 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names
         FreeStyleProject p1 = createFreeStyleProject("p1");
         FreeStyleProject p2 = createFreeStyleProject("p2");
-        p2.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha), false, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
+        p2.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha), false, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT, 0L));
         FreeStyleProject p3 = createFreeStyleProject("p3");
-        p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
+        p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT, 0L));
         FreeStyleProject p4 = createFreeStyleProject("p4");
-        p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
+        p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT, 0L));
         // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we can check jobs inside folders
         assertProjects(alpha, p3);
         assertProjects(beta, p3, p4);


### PR DESCRIPTION
Hi,

This is to enable a configurable interval/delay between start of concurrent builds for a project.
More detail of available in Jira: https://issues.jenkins-ci.org/browse/JENKINS-23368

feedback and questions welcome

thanks
Geoff
