### PR TITLE
This change fixes an issue introduced with the Matrix support around allowing flyweight tasks to throttle a given category

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -192,6 +192,10 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     }
 
     private int buildsOfProjectOnNode(Node node, Task task) {
+        if (!shouldBeThrottled(task, getThrottleJobProperty(task))) {
+            return 0;
+        }
+
         int runCount = 0;
         LOGGER.log(Level.FINE, "Checking for builds of {0} on node {1}", new Object[] {task.getName(), node.getDisplayName()});
 
@@ -202,17 +206,9 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
             for (Executor e : computer.getExecutors()) {
                 runCount += buildsOnExecutor(task, e);
             }
-            
-            ThrottleMatrixProjectOptions matrixOptions = getMatrixOptions(task);
-            if ( matrixOptions.isThrottleMatrixBuilds() && task instanceof MatrixProject) {
-                for (Executor e : computer.getOneOffExecutors()) {
-                    runCount += buildsOnExecutor(task, e);
-                }
-            }
-            if ( matrixOptions.isThrottleMatrixConfigurations() && task instanceof MatrixConfiguration) {
-                for (Executor e : computer.getOneOffExecutors()) {
-                    runCount += buildsOnExecutor(task, e);
-                }
+
+            for (Executor e : computer.getOneOffExecutors()) {
+                runCount += buildsOnExecutor(task, e);
             }
         }
 


### PR DESCRIPTION
Essentially, if a non-Matrix flyweight task in category A was running, we wouldn't count its one-off executor when determining whether another project in category A should be scheduled.

The fix is to count all executors for all tasks that should be throttled instead of only counting one-off executors for Matrix jobs.
