### PR TITLE
[JENKINS-28133] Prevent concurrent builds from exceeding max of category

### DIFF
--- a/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/Messages.properties
@@ -1,5 +1,6 @@
 ThrottleQueueTaskDispatcher.MaxCapacityOnNode=Already running {0} builds on node
 ThrottleQueueTaskDispatcher.MaxCapacityTotal=Already running {0} builds across all nodes
+ThrottleQueueTaskDispatcher.SchedulingAnotherBuild=Already scheduling another build
 ThrottleQueueTaskDispatcher.BuildPending=A build is pending launch
 
 ThrottleMatrixProjectOptions.DisplayName=Additional options for Matrix projects


### PR DESCRIPTION
One ugly hack job but I didn't feel like rewriting the whole implementation to accomplish this.

Accept if you'd like but this is more or less here for anyone else to reference.

Tested against 1.424 and 1.608.