### PR TITLE
[JENKINS-25326] Make work with cloudbees-folder with permissions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.480.3</version>
+    <version>1.424</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>
@@ -113,7 +113,7 @@ THE SOFTWARE.
             <version>2.0.1</version>
             <type>jar</type>
         </dependency>
-        <!-- Requires core 1.480.3 -->
+        <!-- Requires core 1.480.3
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>cloudbees-folder</artifactId>
@@ -126,6 +126,7 @@ THE SOFTWARE.
           <version>1.8.3</version>
           <scope>test</scope>
         </dependency>
+        -->
     </dependencies>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>1.480.3</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>
@@ -112,6 +112,19 @@ THE SOFTWARE.
             <artifactId>jsr305</artifactId>
             <version>2.0.1</version>
             <type>jar</type>
+        </dependency>
+        <!-- Requires core 1.480.3 -->
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>cloudbees-folder</artifactId>
+          <version>4.0</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>credentials</artifactId>
+          <version>1.8.3</version>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 </project>  

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -10,6 +10,8 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Queue;
+import hudson.security.ACL;
+import hudson.security.NotSerilizableSecurityContext;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.Util;
@@ -29,6 +31,8 @@ import jenkins.model.Jenkins;
 
 import net.sf.json.JSONObject;
 
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -199,10 +203,14 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         return categoryTasks;
     }
     private static Item getItem(ItemGroup group, String name) {
-        if (group instanceof Jenkins) {
-            return ((Jenkins) group).getItemMap().get(name);
-        } else {
+        SecurityContext orig = SecurityContextHolder.getContext();
+        NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
+        auth.setAuthentication(ACL.SYSTEM);
+        SecurityContextHolder.setContext(auth);
+        try {
             return group.getItem(name);
+        } finally {
+            SecurityContextHolder.setContext(orig);
         }
     }
     

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -12,7 +12,9 @@ import org.acegisecurity.context.SecurityContextHolder;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 
+/*
 import com.cloudbees.hudson.plugins.folder.Folder;
+*/
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -48,6 +50,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         assertProjects(beta, p3b);
     }
 
+    /*
     // Requires Jenkins >= 1.480.3 and cloudbees-folder-plugin
     @Bug(25326)
     public void testGetCategoryProjectsInFolder() throws Exception {
@@ -56,6 +59,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         p.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList("category"), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
         assertProjects("category", p);
     }
+    */
 
 
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -2,15 +2,22 @@ package hudson.plugins.throttleconcurrents;
 
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
-import hudson.model.Job;
 import hudson.model.Queue;
-import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
+import hudson.security.NotSerilizableSecurityContext;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
 import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
+
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
+
+import jenkins.model.Jenkins;
 
 public class ThrottleJobPropertyTest extends HudsonTestCase {
 
@@ -27,7 +34,6 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
         FreeStyleProject p4 = createFreeStyleProject("p4");
         p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
-        // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we can check jobs inside folders
         assertProjects(alpha, p3);
         assertProjects(beta, p3, p4);
         assertProjects(gamma, p4);
@@ -40,6 +46,15 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         assertProjects(beta, p3, p3b);
         p3.removeProperty(ThrottleJobProperty.class);
         assertProjects(beta, p3b);
+    }
+
+    // Requires Jenkins >= 1.480.3 and cloudbees-folder-plugin
+    @Bug(25326)
+    public void testGetCategoryProjectsInFolder() throws Exception {
+        Folder f = jenkins.createProject(Folder.class, "folder");
+        FreeStyleProject p = f.createProject(FreeStyleProject.class, "p");
+        p.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList("category"), true, THROTTLE_OPTION_CATEGORY, ThrottleMatrixProjectOptions.DEFAULT));
+        assertProjects("category", p);
     }
 
 
@@ -124,25 +139,19 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
 
 
     private void assertProjects(String category, AbstractProject<?,?>... projects) {
-        jenkins.setAuthorizationStrategy(new RejectAllAuthorizationStrategy());
+        // Queue runs as ANONYMOUS.
+        // Ensure throttle-concurrent-builds works even without any permissions for ANONYMOUS.
+        jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
+        SecurityContext orig = SecurityContextHolder.getContext();
+        NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
+        auth.setAuthentication(Jenkins.ANONYMOUS);
+        SecurityContextHolder.setContext(auth);
         try {
             assertEquals(new HashSet<Queue.Task>(Arrays.asList(projects)), new HashSet<Queue.Task>
                     (ThrottleJobProperty.getCategoryTasks(category)));
         } finally {
+            SecurityContextHolder.setContext(orig);
             jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED); // do not check during e.g. rebuildDependencyGraph from delete
-        }
-    }
-    private static class RejectAllAuthorizationStrategy extends AuthorizationStrategy {
-        RejectAllAuthorizationStrategy() {}
-        @Override public ACL getRootACL() {
-            return new AuthorizationStrategy.Unsecured().getRootACL();
-        }
-        @Override public Collection<String> getGroups() {
-            return Collections.emptySet();
-        }
-        @Override public ACL getACL(Job<?,?> project) {
-            fail("not even supposed to be looking at " + project);
-            return super.getACL(project);
         }
     }
 


### PR DESCRIPTION
[JENKINS-25326](https://issues.jenkins-ci.org/browse/JENKINS-25326)

Throttle-concurrent-builds doesn't work with projects inside cloudbees-folder and not accessible from anonymous, as the queue thread work as anonymous.

This change elevates throttle-concurrent-builds to SYSTEM when accessing projects.
