### PR TITLE
[JENKINS-25326] Elevates to SYSTEM when handling throttling for builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>1.554</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>
@@ -112,6 +112,19 @@ THE SOFTWARE.
             <artifactId>jsr305</artifactId>
             <version>2.0.1</version>
             <type>jar</type>
+        </dependency>
+        <!-- Requires core 1.480.3 -->
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>cloudbees-folder</artifactId>
+          <version>4.0</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>credentials</artifactId>
+          <version>1.9.4</version>
+          <scope>test</scope>
         </dependency>
     </dependencies>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.554</version>
+    <version>1.424</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>
@@ -113,7 +113,7 @@ THE SOFTWARE.
             <version>2.0.1</version>
             <type>jar</type>
         </dependency>
-        <!-- Requires core 1.480.3 -->
+        <!-- Requires core 1.480.3
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>cloudbees-folder</artifactId>
@@ -126,6 +126,7 @@ THE SOFTWARE.
           <version>1.9.4</version>
           <scope>test</scope>
         </dependency>
+        -->
     </dependencies>
 </project>  
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -13,6 +13,8 @@ import hudson.model.Queue.Task;
 import hudson.model.labels.LabelAtom;
 import hudson.model.queue.CauseOfBlockage;
 import hudson.model.queue.QueueTaskDispatcher;
+import hudson.security.ACL;
+import hudson.security.NotSerilizableSecurityContext;
 
 import java.util.List;
 import java.util.Set;
@@ -21,11 +23,34 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
+import jenkins.model.Jenkins;
+
 @Extension
 public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @Override
     public CauseOfBlockage canTake(Node node, Task task) {
+        if (Jenkins.getAuthentication() == ACL.SYSTEM) {
+            return canTakeImpl(node, task);
+        }
+        
+        // Throttle-concurrent-builds requires READ permissions for all projects.
+        SecurityContext orig = SecurityContextHolder.getContext();
+        NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
+        auth.setAuthentication(ACL.SYSTEM);
+        SecurityContextHolder.setContext(auth);
+        
+        try {
+            return canTakeImpl(node, task);
+        } finally {
+            SecurityContextHolder.setContext(orig);
+        }
+    }
+    
+    private CauseOfBlockage canTakeImpl(Node node, Task task) {
         
         ThrottleJobProperty tjp = getThrottleJobProperty(task);
         
@@ -35,7 +60,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
 
         if (tjp!=null && tjp.getThrottleEnabled()) {
-            CauseOfBlockage cause = canRun(task, tjp);
+            CauseOfBlockage cause = canRunImpl(task, tjp);
             if (cause != null) return cause;
 
             if (tjp.getThrottleOption().equals("project")) {
@@ -124,6 +149,24 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     }
 
     public CauseOfBlockage canRun(Task task, ThrottleJobProperty tjp) {
+        if (Jenkins.getAuthentication() == ACL.SYSTEM) {
+            return canRunImpl(task, tjp);
+        }
+        
+        // Throttle-concurrent-builds requires READ permissions for all projects.
+        SecurityContext orig = SecurityContextHolder.getContext();
+        NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
+        auth.setAuthentication(ACL.SYSTEM);
+        SecurityContextHolder.setContext(auth);
+        
+        try {
+            return canRunImpl(task, tjp);
+        } finally {
+            SecurityContextHolder.setContext(orig);
+        }
+    }
+    
+    private CauseOfBlockage canRunImpl(Task task, ThrottleJobProperty tjp) {
         if (!shouldBeThrottled(task, tjp)) {
             return null;
         }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
@@ -42,7 +42,9 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.SleepBuilder;
 
+/*
 import com.cloudbees.hudson.plugins.folder.Folder;
+*/
 
 /**
  * Tests that {@link ThrottleJobProperty} actually works for builds.
@@ -164,6 +166,8 @@ public class ThrottleIntegrationTest extends HudsonTestCase {
         assertEquals(1, waterMark.getExecutorWaterMark());
     }
     
+    /*
+    // Requires Jenkins >= 1.480.3 and cloudbees-folder-plugin
     @Bug(25326)
     public void testThrottlingWithCategoryInFolder() throws Exception {
         setupSlave();
@@ -215,4 +219,5 @@ public class ThrottleIntegrationTest extends HudsonTestCase {
         // throttled, and only one build runs at the same time.
         assertEquals(1, waterMark.getExecutorWaterMark());
     }
+    */
 }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -16,6 +16,7 @@
  */
 package hudson.plugins.throttleconcurrents;
 
+import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
@@ -358,7 +359,13 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
                     input.setValueAttribute(logger);
                 }
                 HtmlSelect select = form.getSelectByName("level");
-                HtmlOption option = select.getOptionByValue("fine");
+                HtmlOption option;
+                try {
+                    option = select.getOptionByValue("fine");
+                } catch (ElementNotFoundException e) {
+                    // gets upper case since Jenkins 1.519
+                    option = select.getOptionByValue("FINE");
+                }
                 select.setSelectedAttribute(option, true);
                 break;
             }


### PR DESCRIPTION
[JENKINS-25326](https://issues.jenkins-ci.org/browse/JENKINS-25326)

Throttling doesn't work for projects in cloudbees-folder with latest Jenkins.
As far as I tested, it doesn't work since Jenkins 1.536:

| Jenlkins | Throttling in folder | Note |
|:---------|:---------------------|:-----|
| 1.532    | Works                | |
| 1.535    | Works                | |
| 1.536    | **Doesn't work**     | |
| 1.554    | **Doesn't work**     | |
| 1.642    | **Doesn't work**     | Requires some changes in test codes to compile |

I fix that problem in followng steps in this request:

1. Add a commit to add a test to reproduce the problem. This requires to change the targeted Jenkins version to >= 1.536.
2. Add a commit to fix the problem.
3. Add a commit to revert changes to reproduce the problem, including the change of targeted Jenkins version.