### PR TITLE
Fixing squid:S00122 -  Statements should be on separate lines

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -36,7 +36,9 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
         if (tjp!=null && tjp.getThrottleEnabled()) {
             CauseOfBlockage cause = canRun(task, tjp);
-            if (cause != null) return cause;
+            if (cause != null) {
+            	return cause;
+            }
 
             if (tjp.getThrottleOption().equals("project")) {
                 if (tjp.getMaxConcurrentPerNode().intValue() > 0) {
@@ -100,18 +102,26 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     @Nonnull
     private ThrottleMatrixProjectOptions getMatrixOptions(Task task) {
         ThrottleJobProperty tjp = getThrottleJobProperty(task);
-        if (tjp == null) return ThrottleMatrixProjectOptions.DEFAULT;       
+        if (tjp == null){
+        	return ThrottleMatrixProjectOptions.DEFAULT;       
+        }
         ThrottleMatrixProjectOptions matrixOptions = tjp.getMatrixOptions();
         return matrixOptions != null ? matrixOptions : ThrottleMatrixProjectOptions.DEFAULT;
     }
     
     private boolean shouldBeThrottled(@Nonnull Task task, @CheckForNull ThrottleJobProperty tjp) {
-       if (tjp == null) return false;
-       if (!tjp.getThrottleEnabled()) return false;
+       if (tjp == null) {
+    	   return false;
+       }
+       if (!tjp.getThrottleEnabled()) { 
+    	   return false;
+       }
        
        // Handle matrix options
        ThrottleMatrixProjectOptions matrixOptions = tjp.getMatrixOptions();
-       if (matrixOptions == null) matrixOptions = ThrottleMatrixProjectOptions.DEFAULT;
+       if (matrixOptions == null) {
+    	   matrixOptions = ThrottleMatrixProjectOptions.DEFAULT;
+       }
        if (!matrixOptions.isThrottleMatrixConfigurations() && task instanceof MatrixConfiguration) {
             return false;
        } 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S00122 -  Statements should be on separate lines" information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S00122


Please let me know if you have any questions.
Sameer Misger