### PR TITLE
Update the core dependency to 1.609.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.596.1</version>
+    <version>1.609.3</version>
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>


### PR DESCRIPTION
In throttle-concurrents-1.8.5 the core version has been bumped to 1.596.1. It was a bad idea, because Jenkins 1.535 ... 1.609.2 are known to be unstable due to the issues in the Queue implementation (on-demand thread spawning for executors).

Effectively there are two Jenkins queue implementations now: the legacy one and 1.609.x+. I want to drop the support of the old implementation in order to cleanup the code and to reduce the support efforts.

@abayer @jglick 