### PR TITLE
JENKINS-34294: Added support to throttle Inheritance projects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,12 @@ THE SOFTWARE.
             <artifactId>matrix-project</artifactId>
             <version>1.4.1</version>
         </dependency>
-        
+        <dependency>
+            <groupId>hudson.plugins</groupId>
+            <artifactId>project-inheritance</artifactId>
+            <version>1.5.3</version>
+            <optional>true</optional>
+        </dependency>
         <!-- Dependencies for test -->
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertySelector.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertySelector.java
@@ -1,0 +1,209 @@
+
+package hudson.plugins.throttleconcurrents;
+
+import hudson.Extension;
+import hudson.model.JobProperty;
+import hudson.plugins.project_inheritance.projects.InheritanceProject;
+import hudson.plugins.project_inheritance.projects.inheritance.InheritanceSelector;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+
+
+/**
+ * 
+ * @author Jacek Tomaka
+ * @since TODO
+ */
+
+@Extension(optional = true)
+public class ThrottleJobPropertySelector extends InheritanceSelector<JobProperty<?>> {
+    class ParameterGroup {
+        private List<String> parameters;
+        public ParameterGroup(List<String> parameters){
+            this.parameters = parameters;
+        }
+        @Override
+        public boolean equals(Object other){
+            if (!(other instanceof ParameterGroup)){
+                return false;
+            }
+            ParameterGroup otherParameterGroup = (ParameterGroup)other;
+            if (parameters == null) return otherParameterGroup.parameters == null;
+            if (otherParameterGroup.parameters == null) return false;
+            if (parameters.size()!=otherParameterGroup.parameters.size()) return false;
+            for (int i=0;i<parameters.size();i++){
+                if (!parameters.get(i).equals(otherParameterGroup.parameters.get(i))){
+                    return false;
+                }
+            }
+            return true;
+            
+        }
+        @Override
+        public int hashCode(){
+            if (parameters == null) return 0;
+            if (parameters.isEmpty()) return 1;
+            return parameters.get(0).hashCode()^parameters.size();
+        }
+        public List<String> getParameters() {
+           return parameters;
+        }
+    }
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public boolean isApplicableFor(Class<?> clazz) {
+        return JobProperty.class.isAssignableFrom(clazz);
+    }
+
+    @Override
+    public InheritanceSelector.MODE getModeFor(Class<?> clazz) {
+        if (ThrottleJobProperty.class.isAssignableFrom(clazz))
+            return MODE.MERGE;
+        return MODE.NOT_RESPONSIBLE;
+    }
+
+    @Override
+    public String getObjectIdentifier(JobProperty<?> obj) {
+        if (obj != null && ThrottleJobProperty.class.getName().equals(obj.getClass().getName())) {
+            return ThrottleJobProperty.class.getName();
+        }
+        return null;
+    }
+
+    private ThrottleJobProperty getThrottleJobProperty(JobProperty<?> jobProperty) {
+        if (jobProperty == null)
+            return null;
+        if (!ThrottleJobProperty.class.isAssignableFrom(jobProperty.getClass()))
+            return null;
+        return (ThrottleJobProperty) jobProperty;
+    }
+
+    private List<String> getMergedCategories(List<String> priorCategories, List<String> latterCategories) {
+        if (priorCategories == null || priorCategories.isEmpty())
+            return latterCategories;
+        if (latterCategories == null || latterCategories.isEmpty())
+            return priorCategories;
+        HashSet<String> uniqueCategories = new HashSet<String>(priorCategories);
+        for (String category : latterCategories) {
+            if (!uniqueCategories.contains(category)) {
+                uniqueCategories.add(category);
+            }
+        }
+        return new ArrayList<String>(uniqueCategories);
+    }
+
+    private Integer getLowerOfMaximums(Integer max1, Integer max2) {
+        if (max1 == null || max2 == null)
+            return max2;
+        return new Integer(Math.min(max1.intValue(), max2.intValue()));
+    }
+
+    String getMergedThrottleOption(String prior, String latter) {
+        return "CATEGORY";// TODO: JTO think about it.
+    }
+
+    private List<List<String>> getMergedParameterGroupsToCompare(boolean mergedIsLimitOneJobWithMatchingParameters,
+            List<List<String>> priorParameterGroupsToCompare, List<List<String>> latterParameterGroupsToCompare) {
+        if (mergedIsLimitOneJobWithMatchingParameters) {
+            return getMergedParameterGroupsToCompare(priorParameterGroupsToCompare, latterParameterGroupsToCompare);
+        } else {
+            return new ArrayList<List<String>>();
+        }
+    }
+
+    private boolean getMergedLimitOneJobWithMatchingParameters(boolean limitOneJobWithMatchingParamsPrior,
+            boolean limitOneJobWithMatchingParamsLatter) {
+        return limitOneJobWithMatchingParamsLatter || limitOneJobWithMatchingParamsPrior;
+    }
+    private List<List<String>> getMergedParameterGroupsToCompare(List<List<String>> prior, List<List<String>> latter){
+        if (prior == null || prior.isEmpty() ) return latter;
+        if (latter == null || latter.isEmpty() ) return prior;
+        HashSet<ParameterGroup> uniqueParameterGroup = new HashSet<ParameterGroup>(wrapParameterGroups(prior));
+        for(ParameterGroup parameterGroup:wrapParameterGroups(latter)){
+            if (!uniqueParameterGroup.contains(parameterGroup)){
+                uniqueParameterGroup.add(parameterGroup);
+            }
+        }
+        return unwrapParameterGroups(uniqueParameterGroup);
+    }
+    private List<ParameterGroup> wrapParameterGroups(Collection<List<String>> parameterGroups) {
+        if (parameterGroups == null || parameterGroups.isEmpty()){
+            return new ArrayList<ParameterGroup>(0);
+        }
+        List<ParameterGroup> wrappedParameterGroups = new ArrayList<ParameterGroup>(parameterGroups.size());
+        for (List<String> parameterGroup:parameterGroups){
+            wrappedParameterGroups.add(new ParameterGroup(parameterGroup));
+        }
+        return wrappedParameterGroups;
+    }
+    private List<List<String>> unwrapParameterGroups(Collection<ParameterGroup> parameterGroups){
+        if (parameterGroups == null || parameterGroups.isEmpty()){
+            return new ArrayList<List<String>>(0);
+        }
+        List<List<String>> unwrappedParameterGroups = new ArrayList<List<String>>(parameterGroups.size());
+        for (ParameterGroup parameterGroup:parameterGroups){
+            unwrappedParameterGroups.add(parameterGroup.getParameters());
+        }
+        return unwrappedParameterGroups;
+    }
+    @Override
+    public ThrottleJobProperty merge(JobProperty<?> prior, JobProperty<?> latter, InheritanceProject caller) {
+        ThrottleJobProperty priorThrottleJobProperty = getThrottleJobProperty(prior);
+        ThrottleJobProperty latterThrottleJobProperty = getThrottleJobProperty(latter);
+        if (priorThrottleJobProperty == null || !priorThrottleJobProperty.getThrottleEnabled()) {
+            return latterThrottleJobProperty;
+        }
+        if (latterThrottleJobProperty == null || !latterThrottleJobProperty.getThrottleEnabled()) {
+            return priorThrottleJobProperty;
+        }
+        boolean mergedThrottleEnabled = true;
+
+        List<String> mergedCategories = getMergedCategories(priorThrottleJobProperty.getCategories(), 
+                latterThrottleJobProperty.getCategories());
+        
+        Integer mergedMaxConcurrentPerNodePerProject = getLowerOfMaximums(priorThrottleJobProperty.getMaxConcurrentPerNode(),
+                latterThrottleJobProperty.getMaxConcurrentPerNode());
+        
+        Integer mergedMaxConcurrentTotalPerProject = getLowerOfMaximums(
+                priorThrottleJobProperty.getMaxConcurrentTotal(), latterThrottleJobProperty.getMaxConcurrentTotal());
+        
+        String mergedThrottleOption = getMergedThrottleOption(priorThrottleJobProperty.getThrottleOption(),
+                latterThrottleJobProperty.getThrottleOption());
+        
+        boolean mergedIsLimitOneJobWithMatchingParameters = getMergedLimitOneJobWithMatchingParameters(
+                priorThrottleJobProperty.isLimitOneJobWithMatchingParams(),
+                latterThrottleJobProperty.isLimitOneJobWithMatchingParams());
+        
+        String mergedParamsToUseForLimit = null;
+        
+        ThrottleMatrixProjectOptions mergedThrottleMatrixProjectOptions = null;
+        
+        List<List<String>> mergedParameterGroupsToCompare = getMergedParameterGroupsToCompare(
+                mergedIsLimitOneJobWithMatchingParameters, priorThrottleJobProperty.getParameterGroupsToCompare(),
+                latterThrottleJobProperty.getParameterGroupsToCompare());
+        
+        return new ThrottleJobProperty(mergedMaxConcurrentPerNodePerProject, mergedMaxConcurrentTotalPerProject,
+                mergedCategories, mergedThrottleEnabled, mergedThrottleOption,
+                mergedIsLimitOneJobWithMatchingParameters, mergedParamsToUseForLimit,
+                mergedThrottleMatrixProjectOptions, mergedParameterGroupsToCompare);
+    }
+
+    @Override
+    public JobProperty<?> handleSingleton(JobProperty<?> jobProperty, InheritanceProject caller) {
+        if (jobProperty == null || caller == null)
+            return jobProperty;
+        if (caller.isAbstract)
+            return jobProperty;
+
+        if (!ThrottleJobProperty.class.isAssignableFrom(jobProperty.getClass()))
+            return jobProperty;
+       
+
+        return new ThrottleJobProperty((ThrottleJobProperty)jobProperty, caller);
+    }
+}

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -265,34 +265,34 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
             return false;
         }
         Computer computer = node.toComputer();
-        List<String> paramsToCompare = tjp.getParamsToCompare();
         List<ParameterValue> itemParams = getParametersFromQueueItem(item);
-
-        if (paramsToCompare.size() > 0) {
-            itemParams = doFilterParams(paramsToCompare, itemParams);
-        }
-
-        if (computer != null) {
-            for (Executor exec : computer.getExecutors()) {
-                if (item != null && item.task != null) {
-                    // TODO: refactor into a nameEquals helper method
-                    final Queue.Executable currentExecutable = exec.getCurrentExecutable();
-                    final SubTask parentTask = currentExecutable != null ? currentExecutable.getParent() : null;
-                    if (currentExecutable != null && parentTask != null &&
-                            parentTask.getOwnerTask() != null &&
-                            parentTask.getOwnerTask().getName().equals(item.task.getName())) {
-                        List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
-                        executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
-
-                        if (executingUnitParams.containsAll(itemParams)) {
-                            LOGGER.log(Level.FINE, "build (" + exec.getCurrentWorkUnit() +
-                                    ") with identical parameters (" +
-                                    executingUnitParams + ") is already running.");
-                            return true;
-                        }
-                    }
-                }
-            }
+        for (List<String> paramsToCompare: tjp.getParameterGroupsToCompare()){
+	        if (paramsToCompare.size() > 0) {
+	            itemParams = doFilterParams(paramsToCompare, itemParams);
+	        }
+	
+	        if (computer != null) {
+	            for (Executor exec : computer.getExecutors()) {
+	                if (item != null && item.task != null) {
+	                    // TODO: refactor into a nameEquals helper method
+	                    final Queue.Executable currentExecutable = exec.getCurrentExecutable();
+	                    final SubTask parentTask = currentExecutable != null ? currentExecutable.getParent() : null;
+	                    if (currentExecutable != null && parentTask != null &&
+	                            parentTask.getOwnerTask() != null &&
+	                            parentTask.getOwnerTask().getName().equals(item.task.getName())) {
+	                        List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
+	                        executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
+	
+	                        if (executingUnitParams.containsAll(itemParams)) {
+	                            LOGGER.log(Level.FINE, "build (" + exec.getCurrentWorkUnit() +
+	                                    ") with identical parameters (" +
+	                                    executingUnitParams + ") is already running.");
+	                            return true;
+	                        }
+	                    }
+	                }
+	            }
+	        }
         }
         return false;
     }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentFreeStyleProjectTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentFreeStyleProjectTest.java
@@ -1,0 +1,5 @@
+package hudson.plugins.throttleconcurrents;
+
+public class ThrottleConcurrentFreeStyleProjectTest extends ThrottleConcurrentTest<ThrottleConcurrentTest.GivenStage> {
+
+}

--- a/src/test/java/hudson/plugins/throttleconcurrents/inheritance/ThrottleConcurrentInheritanceProjectTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/inheritance/ThrottleConcurrentInheritanceProjectTest.java
@@ -1,0 +1,69 @@
+package hudson.plugins.throttleconcurrents.inheritance;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Semaphore;
+import org.jvnet.hudson.test.JenkinsRule;
+import com.google.common.collect.ImmutableList;
+import hudson.model.AbstractBuild;
+import hudson.model.Descriptor;
+import hudson.plugins.throttleconcurrents.ThrottleJobProperty;
+import hudson.plugins.throttleconcurrents.ThrottleConcurrentTest;
+import hudson.plugins.throttleconcurrents.testutils.inheritance.InheritanceProjectRule;
+import hudson.plugins.throttleconcurrents.testutils.inheritance.InheritanceProjectsPair;
+import hudson.tasks.Builder;
+import hudson.util.DescribableList;
+import hudson.plugins.project_inheritance.projects.InheritanceProject;
+import hudson.plugins.project_inheritance.projects.InheritanceProject.IMode;
+
+
+public class ThrottleConcurrentInheritanceProjectTest extends ThrottleConcurrentTest<ThrottleConcurrentInheritanceProjectTest.GivenStage>{
+    private static class RunProject implements Callable<AbstractBuild<?, ?>> {
+        private final Semaphore inQueue = new Semaphore(1);
+        
+        private final InheritanceProject project;
+        protected final JenkinsRule j;
+
+        private RunProject(JenkinsRule j, String categoryName) throws IOException {
+            this.j = j;
+            project = createProjectInCategory(categoryName);
+        }
+
+        protected InheritanceProject createProjectInCategory(String categoryName) throws IOException {
+            InheritanceProjectsPair inheritanceProjectsPair = ((InheritanceProjectRule)j).createInheritanceProjectDerivedWithBase();
+            inheritanceProjectsPair.getBase().addProperty(
+                    new ThrottleJobProperty(0, 0, ImmutableList.of(categoryName), 
+                            true, "category", false, null, null));
+            inheritanceProjectsPair.getBase().getBuildersList(IMode.LOCAL_ONLY).add(new SemaphoreBuilder(inQueue));
+            //InheritanceProject.clearBuffers(inheritanceProjectsPair.getDerived());
+            //DescribableList<Builder, Descriptor<Builder>> list = inheritanceProjectsPair.getDerived().getBuildersList();
+            return inheritanceProjectsPair.getDerived();
+        }
+
+        @Override
+        public AbstractBuild<?, ?> call() throws Exception {
+            System.out.println(String.format("Thread %s %d will attempt to acquire semaphore %s",Thread.currentThread().getName(), Thread.currentThread().getId() , project.toString()));
+            inQueue.acquire();
+            try{
+                System.out.println(String.format("Thread %s %d acquired semaphore %s",Thread.currentThread().getName(), Thread.currentThread().getId() , project.toString() ));
+                AbstractBuild<?, ?> build = j.buildAndAssertSuccess(project);
+                System.out.println(String.format("Thread %s %d returned %s",Thread.currentThread().getName(), Thread.currentThread().getId(), build == null?"NULL":build.toString()));
+                return build;
+            }catch (Exception ex){
+                ex.printStackTrace();
+                throw ex;
+            }
+        }
+    }
+
+   
+    public static class GivenStage extends hudson.plugins.throttleconcurrents.ThrottleConcurrentTest.GivenStage {
+        public Callable<AbstractBuild<?, ?>> createRunProject(JenkinsRule j, String categoryName) throws IOException {
+            return new RunProject(j, categoryName);
+        }
+    }
+   public ThrottleConcurrentInheritanceProjectTest(){
+       super();
+       this.j =  new InheritanceProjectRule();
+   }
+}

--- a/src/test/java/hudson/plugins/throttleconcurrents/inheritance/ThrottleConcurrentInheritanceProjectTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/inheritance/ThrottleConcurrentInheritanceProjectTest.java
@@ -6,13 +6,10 @@ import java.util.concurrent.Semaphore;
 import org.jvnet.hudson.test.JenkinsRule;
 import com.google.common.collect.ImmutableList;
 import hudson.model.AbstractBuild;
-import hudson.model.Descriptor;
 import hudson.plugins.throttleconcurrents.ThrottleJobProperty;
 import hudson.plugins.throttleconcurrents.ThrottleConcurrentTest;
 import hudson.plugins.throttleconcurrents.testutils.inheritance.InheritanceProjectRule;
 import hudson.plugins.throttleconcurrents.testutils.inheritance.InheritanceProjectsPair;
-import hudson.tasks.Builder;
-import hudson.util.DescribableList;
 import hudson.plugins.project_inheritance.projects.InheritanceProject;
 import hudson.plugins.project_inheritance.projects.InheritanceProject.IMode;
 
@@ -35,24 +32,14 @@ public class ThrottleConcurrentInheritanceProjectTest extends ThrottleConcurrent
                     new ThrottleJobProperty(0, 0, ImmutableList.of(categoryName), 
                             true, "category", false, null, null));
             inheritanceProjectsPair.getBase().getBuildersList(IMode.LOCAL_ONLY).add(new SemaphoreBuilder(inQueue));
-            //InheritanceProject.clearBuffers(inheritanceProjectsPair.getDerived());
-            //DescribableList<Builder, Descriptor<Builder>> list = inheritanceProjectsPair.getDerived().getBuildersList();
             return inheritanceProjectsPair.getDerived();
         }
 
         @Override
         public AbstractBuild<?, ?> call() throws Exception {
-            System.out.println(String.format("Thread %s %d will attempt to acquire semaphore %s",Thread.currentThread().getName(), Thread.currentThread().getId() , project.toString()));
             inQueue.acquire();
-            try{
-                System.out.println(String.format("Thread %s %d acquired semaphore %s",Thread.currentThread().getName(), Thread.currentThread().getId() , project.toString() ));
-                AbstractBuild<?, ?> build = j.buildAndAssertSuccess(project);
-                System.out.println(String.format("Thread %s %d returned %s",Thread.currentThread().getName(), Thread.currentThread().getId(), build == null?"NULL":build.toString()));
-                return build;
-            }catch (Exception ex){
-                ex.printStackTrace();
-                throw ex;
-            }
+            return j.buildAndAssertSuccess(project);
+            
         }
     }
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/testutils/inheritance/InheritanceProjectRule.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/testutils/inheritance/InheritanceProjectRule.java
@@ -1,0 +1,28 @@
+package hudson.plugins.throttleconcurrents.testutils.inheritance;
+
+import java.io.IOException;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.plugins.project_inheritance.projects.InheritanceProject;
+import hudson.plugins.project_inheritance.projects.references.SimpleProjectReference;
+
+public class InheritanceProjectRule extends JenkinsRule {
+    InheritanceProject createInheritanceProject() throws IOException{
+        return createInheritanceProject(createUniqueProjectName());
+    }
+    InheritanceProject createInheritanceProject(String name) throws IOException{
+        return jenkins.createProject(InheritanceProject.class, name);
+    }
+    /**
+     * Returns BASE,DERIVED projects
+     * @throws IOException 
+     */
+    public InheritanceProjectsPair createInheritanceProjectDerivedWithBase() throws IOException{
+        String baseProjectName = createUniqueProjectName();
+        InheritanceProject base = createInheritanceProject(baseProjectName);
+        InheritanceProject derived = createInheritanceProject();
+        derived.addParentReference(new SimpleProjectReference(baseProjectName));
+        return new InheritanceProjectsPair(base, derived);
+    }
+}

--- a/src/test/java/hudson/plugins/throttleconcurrents/testutils/inheritance/InheritanceProjectsPair.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/testutils/inheritance/InheritanceProjectsPair.java
@@ -1,0 +1,22 @@
+package hudson.plugins.throttleconcurrents.testutils.inheritance;
+
+import hudson.plugins.project_inheritance.projects.InheritanceProject;
+/**
+ * @author Jacek Tomaka
+ */
+public class InheritanceProjectsPair {
+
+    private InheritanceProject base;
+    private InheritanceProject derived;
+    public InheritanceProject getBase() {
+        return base;
+    }
+    public InheritanceProject getDerived() {
+        return derived;
+    }
+
+    public InheritanceProjectsPair(InheritanceProject base, InheritanceProject derived){
+        this.base = base;
+        this.derived = derived;
+    }
+}


### PR DESCRIPTION
Added support to throttle builds of inheritance-project: 
- Example
  
  Project **D1** and **D2** inherit from project B which inherits from project **A** and: 
  1. project **A** has configured throttling for category _**C1**_  and project **B** has configured throttling for category **_C2_** 
  
  then: 
  
  Projects **D1** and **D2** will act as if they had configured category for **_C1_** and **_C2_**. 
- Example2:
  Project **D1** and **D2** inherit from project **B** which inherits from project **A** and: 
  1. project **A** has configured throttling for project and MaxConcurrentPerNode = 1,    MaxConcurrentTotal=4
  2. project **B** has configured throttling for project and MaxConcurrentPerNode = 2, MaxConcurrentTotal=3
  
  then: 
  
  Projects **D1** and **D2** will act as if they had configured **_MaxConcurrentPerNode = 1, MaxConcurrentTotal=3_**. Projects **D1** and **D2** will be independent. 
