### PR TITLE
[JENKINS-44747] Limit the amount of time categoriesForPipeline can run

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,6 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
             <version>2.13</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
@@ -42,6 +43,7 @@ import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graph.StepNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.LinearBlockHoppingScanner;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.support.concurrent.Timeout;
 import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution.PlaceholderTask;
 
 @Extension
@@ -407,7 +409,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     private List<String> categoriesForPipeline(Task task) {
         if (task instanceof PlaceholderTask) {
             PlaceholderTask placeholderTask = (PlaceholderTask)task;
-            try {
+            try (Timeout t = Timeout.limit(100, TimeUnit.MILLISECONDS)) {
                 FlowNode firstThrottle = firstThrottleStartNode(placeholderTask.getNode());
                 Run<?,?> r = placeholderTask.run();
                 if (firstThrottle != null && r != null) {


### PR DESCRIPTION
[JENKINS-44747](https://issues.jenkins-ci.org/browse/JENKINS-44747)

Not sure if this is the right fix, but seems prudent to start here at least. Untested, since I do not know how to reproduce.

I suspect the root issue is that an `ExecutorPickle` (in the posted thread dump, called from `jenkins.util.Timer [#1]`) is trying to resume a `node` block from some build, but at the same time the dispatcher is attempting to decide whether to take another `node` block from the same build; until all the pickles are rehydrated successfully, the build will not resume, and `StepContext.get` will wait—hence a deadlock. (`ThrottleStepTest` does seem to check this kind of scenario, so perhaps it is timing-dependent if so.)

`ExecutorStepExecution.getNode` could perhaps check `!context.ready` and return `null` but this might be considered surprising. Anyway, modulo logging, this would result in the same behavior—an empty list of categories, thus allowing the block to proceed—so if there is a better fix it would presumably to have to stop relying on `FlowNode.id`. Perhaps you could key blocks by `PlaceholderTask.cookie` instead, though I am loath to expose this as an API.

@reviewbybees