### PR TITLE
POM scm url was wrong.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ THE SOFTWARE.
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/throttle-concurrent-builds-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/throttle-concurrent-builds-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/throttle-concurrents-plugin</url>
+    <url>http://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
This broke links like on https://jenkins.io/doc/developer/extensions/jenkins-core/#jobproperty

cc @reviewbybees 