### PR TITLE
[JENKINS-54578] Cannot delete last category

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,16 +170,19 @@ THE SOFTWARE.
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.2.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <version>1.2.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,12 @@ THE SOFTWARE.
             <version>0.7.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>  
 

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,21 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
             <version>1.15</version>

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -409,6 +409,10 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+            if (!formData.has("categories")) {
+                this.categories = null;
+            }
+
             req.bindJSON(this, formData);
             save();
             return true;


### PR DESCRIPTION
It was impossible to delete all categories (neither at once nor one by
one), since when not receiving any categories, the last-saved categories
took precedence. This has been solved by initializing the categories
property when not receiving the categories from the configuration form.