### PR TITLE
Fix same params detection (documented "comma" does not work)

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -219,11 +219,11 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
     }
 
     /**
-     * Set the paramsToCompare list of Strings from the user-input
-     * token-separated String.
+     * @param paramsToUseForLimit   Set the paramsToCompare list
+     * of Strings from the user-input token-separated String.
      *
-     * @return None, but the this.paramsToCompare will be a valid
-     * populated or empty array (not a null) after this call.
+     * There is no return, but the this.paramsToCompare will be a
+     * valid non-null populated or empty array after this call.
      */
     public void setParamsToCompare(String paramsToUseForLimit) {
         // If there is any contents, tell GC that it is reapable

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -222,7 +222,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         if (paramsToCompare == null) {
             if ((paramsToUseForLimit != null)) {
                 if ((paramsToUseForLimit.length() > 0)) {
-                    paramsToCompare = Arrays.asList(paramsToUseForLimit.split(",\\s*|\\s+"));
+                    paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(",\\s*|\\s+")));
                 }
                 else {
                     paramsToCompare = new ArrayList<String>();

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -51,10 +51,6 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
     // Replaced by categories, to support, well, multiple categories per job (starting from 1.3)
     @Deprecated transient String category;
 
-    // Documentation only states "," but its use was broken for so long,
-    // that probably people used de-facto working whitespace instead.
-    private final static String PARAMS_LIMIT_SEPARATOR = ",\\s*|\\s+";
-
     private Integer maxConcurrentPerNode;
     private Integer maxConcurrentTotal;
     private List<String> categories;
@@ -66,6 +62,10 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
 
     private String paramsToUseForLimit;
     private transient List<String> paramsToCompare;
+
+    // Documentation only stated "," but its use was broken for so long,
+    // that probably people used de-facto working whitespace instead.
+    private final static String PARAMS_LIMIT_SEPARATOR = ",\\s*|\\s+";
 
     /**
      * Store a config version so we're able to migrate config on various

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -231,7 +231,15 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
 
         if ((paramsToUseForLimit != null)) {
             if ((paramsToUseForLimit.length() > 0)) {
-                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
+                List<String> list = new ArrayList<String>(Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR))));
+                // Due to type casting, DO NOT MERGE with the line above
+                // in accordance with https://stackoverflow.com/a/5520808/4715872
+                // Logically, we should only remove all blanks "" and the
+                // split() should have taken care of other chars... but
+                // better safe than sorry. Also remove("") did not seem
+                // to cut it for more than one blank entry in the List.
+                list.removeAll(Arrays.asList("", " ", "\n", "\t", ","));
+                this.paramsToCompare = list;
             }
             else {
                 this.paramsToCompare = new ArrayList<String>();

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -91,7 +91,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         this.paramsToUseForLimit = paramsToUseForLimit;
         if ((this.paramsToUseForLimit != null)) {
             if ((this.paramsToUseForLimit.length() > 0)) {
-                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(StringUtils.split(this.paramsToUseForLimit)));
+                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(this.paramsToUseForLimit.split(",\\s*|\\s+")));
             }
             else {
                 this.paramsToCompare = new ArrayList<String>();
@@ -222,7 +222,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         if (paramsToCompare == null) {
             if ((paramsToUseForLimit != null)) {
                 if ((paramsToUseForLimit.length() > 0)) {
-                    paramsToCompare = Arrays.asList(paramsToUseForLimit.split(","));
+                    paramsToCompare = Arrays.asList(paramsToUseForLimit.split(",\\s*|\\s+"));
                 }
                 else {
                     paramsToCompare = new ArrayList<String>();

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -60,6 +60,12 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
     private transient boolean throttleConfiguration;
     private @CheckForNull ThrottleMatrixProjectOptions matrixOptions;
 
+    // The paramsToUseForLimit is assigned by end-user configuration and
+    // is generally a string with names of build arguments to consider,
+    // and is empty, or has one arg name, or a token-separated list of
+    // such names (see PARAMS_LIMIT_SEPARATOR) below.
+    // The paramsToCompare is an array of arg name strings, one per
+    // list entry, processed from paramsToUseForLimit.
     private String paramsToUseForLimit;
     private transient List<String> paramsToCompare;
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -99,17 +99,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         this.limitOneJobWithMatchingParams = limitOneJobWithMatchingParams;
         this.matrixOptions = matrixOptions;
         this.paramsToUseForLimit = paramsToUseForLimit;
-        if ((this.paramsToUseForLimit != null)) {
-            if ((this.paramsToUseForLimit.length() > 0)) {
-                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(this.paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
-            }
-            else {
-                this.paramsToCompare = new ArrayList<String>();
-            }
-        }
-        else {
-            this.paramsToCompare = new ArrayList<String>();
-        }
+        this.setParamsToCompare(this.paramsToUseForLimit);
     }
 
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -222,19 +222,45 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
                 : ThrottleMatrixProjectOptions.DEFAULT.isThrottleMatrixConfigurations();
     }
 
-    public List<String> getParamsToCompare() {
-        if (paramsToCompare == null) {
-            if ((paramsToUseForLimit != null)) {
-                if ((paramsToUseForLimit.length() > 0)) {
-                    paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
-                }
-                else {
-                    paramsToCompare = new ArrayList<String>();
-                }
+    /**
+     * Set the paramsToCompare list of Strings from the user-input
+     * token-separated String.
+     *
+     * @return None, but the this.paramsToCompare will be a valid
+     * populated or empty array (not a null) after this call.
+     */
+    public void setParamsToCompare(String paramsToUseForLimit) {
+        // If there is any contents, tell GC that it is reapable
+        this.paramsToCompare = null;
+
+        if ((paramsToUseForLimit != null)) {
+            if ((paramsToUseForLimit.length() > 0)) {
+                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
             }
             else {
-                paramsToCompare = new ArrayList<String>();
+                this.paramsToCompare = new ArrayList<String>();
             }
+        }
+        else {
+            this.paramsToCompare = new ArrayList<String>();
+        }
+    }
+
+    /**
+     * Returns a copy of this.paramsToCompare, and (unlike a proper getter)
+     * if it was not set yet, make sure first to populate this array from
+     * the user-provided this.paramsToUseForLimit string. Note that this
+     * call only re-synchronizes paramsToCompare from paramsToUseForLimit
+     * if paramsToCompare was null, so that normally should not happen. This
+     * logic was present here before refactoring it into setParamsToCompare()
+     * above which allows to actually update the cached array on demand if
+     * needed later (e.g. when/if a setParamsToUseForLimit() is introduced).
+     *
+     * @return A populated or empty array (not a null) after this call.
+     */
+    public List<String> getParamsToCompare() {
+        if (paramsToCompare == null) {
+            this.setParamsToCompare(this.paramsToUseForLimit);
         }
         return paramsToCompare;
     }

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -50,7 +50,11 @@ import org.kohsuke.stapler.StaplerRequest;
 public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
     // Replaced by categories, to support, well, multiple categories per job (starting from 1.3)
     @Deprecated transient String category;
-    
+
+    // Documentation only states "," but its use was broken for so long,
+    // that probably people used de-facto working whitespace instead.
+    private final static String PARAMS_LIMIT_SEPARATOR = ",\\s*|\\s+";
+
     private Integer maxConcurrentPerNode;
     private Integer maxConcurrentTotal;
     private List<String> categories;
@@ -91,7 +95,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         this.paramsToUseForLimit = paramsToUseForLimit;
         if ((this.paramsToUseForLimit != null)) {
             if ((this.paramsToUseForLimit.length() > 0)) {
-                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(this.paramsToUseForLimit.split(",\\s*|\\s+")));
+                this.paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(this.paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
             }
             else {
                 this.paramsToCompare = new ArrayList<String>();
@@ -222,7 +226,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         if (paramsToCompare == null) {
             if ((paramsToUseForLimit != null)) {
                 if ((paramsToUseForLimit.length() > 0)) {
-                    paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(",\\s*|\\s+")));
+                    paramsToCompare = Arrays.asList(ArrayUtils.nullToEmpty(paramsToUseForLimit.split(PARAMS_LIMIT_SEPARATOR)));
                 }
                 else {
                     paramsToCompare = new ArrayList<String>();

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -334,13 +334,14 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
             itemParams = doFilterParams(paramsToCompare, itemParams);
         }
 
+        String itemTaskName = item.task.getName();
         if (computer != null) {
             for (Executor exec : computer.getExecutors()) {
                 // TODO: refactor into a nameEquals helper method
                 final Queue.Executable currentExecutable = exec.getCurrentExecutable();
                 final SubTask parentTask = currentExecutable != null ? currentExecutable.getParent() : null;
                 if (currentExecutable != null &&
-                        parentTask.getOwnerTask().getName().equals(item.task.getName())) {
+                        parentTask.getOwnerTask().getName().equals(itemTaskName)) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
                     if (paramsToCompare.size() > 0) {
                         executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -332,7 +332,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         List<ParameterValue> itemParams = getParametersFromQueueItem(item);
 
         if (paramsToCompareSize > 0) {
-            LOGGER.log(Level.FINE, "filter itemParams " + itemParams +
+            LOGGER.log(Level.FINER, "filter itemParams " + itemParams +
                     " (from queue) to only pick up to " + paramsToCompareSize +
                     ": " + paramsToCompare + " (from throttle config)");
             itemParams = doFilterParams(paramsToCompare, itemParams);
@@ -354,7 +354,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                         parentTask.getOwnerTask().getName().equals(itemTaskName)) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
                     if (paramsToCompareSize > 0) {
-                        LOGGER.log(Level.FINE, "filter executingUnitParams" +
+                        LOGGER.log(Level.FINER, "filter executingUnitParams" +
                                 " on " + computer.getDisplayName() + "#" + exec.getNumber() +
                                 " in build (" + exec.getCurrentWorkUnit() + ") from original " +
                                 executingUnitParams + " to only pick up to " +
@@ -400,27 +400,27 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
      */
     private List<ParameterValue> doFilterParams(List<String> paramsToCompare, List<ParameterValue> OriginalParams) {
         if (paramsToCompare.isEmpty()) {
-            LOGGER.log(Level.FINE, "doFilterParams(): paramsToCompare.isEmpty() => return OriginalParams");
+            LOGGER.log(Level.FINEST, "paramsToCompare.isEmpty() => return OriginalParams");
             return OriginalParams;
         }
 
         List<ParameterValue> newParams = new ArrayList<ParameterValue>();
-        LOGGER.log(Level.FINE, "doFilterParams(): filtering by paramsToCompare = " + paramsToCompare);
+        LOGGER.log(Level.FINEST, "filtering by paramsToCompare = " + paramsToCompare);
 
         for (ParameterValue p : OriginalParams) {
-            LOGGER.log(Level.FINE, "doFilterParams(): checking if original " +
+            LOGGER.log(Level.FINEST, "checking if original " +
                 p.getName() + " is on our list of paramsToCompare?.." );
             if (paramsToCompare.contains(p.getName())) {
-                LOGGER.log(Level.FINE, "doFilterParams(): we have a hit in OriginalParams: " + p);
+                LOGGER.log(Level.FINEST, "we have a hit in OriginalParams: " + p);
                 newParams.add(p);
             }
         }
         if (newParams.size() == 0 ) {
-            LOGGER.log(Level.WARNING, "doFilterParams(): Error selecting params," +
+            LOGGER.log(Level.WARNING, "Error selecting params," +
                     " got no hits of " + paramsToCompare + " in " + OriginalParams +
                     " : is the job configuration valid?");
         } else if (newParams.size() < paramsToCompare.size() ) {
-            LOGGER.log(Level.WARNING, "doFilterParams(): Error selecting params," +
+            LOGGER.log(Level.WARNING, "Error selecting params," +
                     " not all of " + paramsToCompare + " were present in " + OriginalParams +
                     " : is the job configuration valid?");
         }

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -347,7 +347,8 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                     if (executingUnitParams.containsAll(itemParams)) {
                         LOGGER.log(Level.FINE, "build (" + exec.getCurrentWorkUnit() +
                                 ") with identical parameters (" +
-                                executingUnitParams + ") is already running.");
+                                executingUnitParams + ") is already running " +
+                                "on node '" + node.getDisplayName() + "'.");
                         return true;
                     }
                 }

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -332,7 +332,11 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         List<ParameterValue> itemParams = getParametersFromQueueItem(item);
 
         if (paramsToCompareSize > 0) {
+            LOGGER.log(Level.FINE, "filter itemParams " + itemParams +
+                    " to only pick " + paramsToCompare);
             itemParams = doFilterParams(paramsToCompare, itemParams);
+            LOGGER.log(Level.FINE, "filtering got " + itemParams.size() +
+                    " itemParams : " + itemParams );
         }
 
         String itemTaskName = item.task.getName();
@@ -349,7 +353,11 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                         parentTask.getOwnerTask().getName().equals(itemTaskName)) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
                     if (paramsToCompareSize > 0) {
+                        LOGGER.log(Level.FINE, "filter executingUnitParams " + executingUnitParams +
+                                " to only pick " + paramsToCompare);
                         executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
+                        LOGGER.log(Level.FINE, "filtering got " + executingUnitParams.size() +
+                                " executingUnitParams : " + executingUnitParams );
                     }
 
                     // An already executing work unit (of the same name) can have more

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -328,9 +328,10 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
         Computer computer = node.toComputer();
         List<String> paramsToCompare = tjp.getParamsToCompare();
+        Integer paramsToCompareSize = paramsToCompare.size();
         List<ParameterValue> itemParams = getParametersFromQueueItem(item);
 
-        if (paramsToCompare.size() > 0) {
+        if (paramsToCompareSize > 0) {
             itemParams = doFilterParams(paramsToCompare, itemParams);
         }
 
@@ -347,7 +348,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 if (currentExecutable != null &&
                         parentTask.getOwnerTask().getName().equals(itemTaskName)) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
-                    if (paramsToCompare.size() > 0) {
+                    if (paramsToCompareSize > 0) {
                         executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
                     }
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -393,6 +393,16 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 newParams.add(p);
             }
         }
+        if (newParams.size() == 0 ) {
+            LOGGER.log(Level.WARNING, "Error selecting params, got no hits of " +
+                    params + " in " + OriginalParams +
+                    " : is the job configuration valid?");
+        } else if (newParams.size() < params.size() ) {
+            LOGGER.log(Level.WARNING, "Error selecting params, not all of " +
+                    params + " were present in " + OriginalParams +
+                    " : is the job configuration valid?");
+        }
+
         return newParams;
     }
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -54,20 +54,20 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         if (Jenkins.getAuthentication() == ACL.SYSTEM) {
             return canTakeImpl(node, task);
         }
-        
+
         // Throttle-concurrent-builds requires READ permissions for all projects.
         SecurityContext orig = SecurityContextHolder.getContext();
         NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
         auth.setAuthentication(ACL.SYSTEM);
         SecurityContextHolder.setContext(auth);
-        
+
         try {
             return canTakeImpl(node, task);
         } finally {
             SecurityContextHolder.setContext(orig);
         }
     }
-    
+
     private CauseOfBlockage canTakeImpl(Node node, Task task) {
         final Jenkins jenkins = Jenkins.getActiveInstance();
         ThrottleJobProperty tjp = getThrottleJobProperty(task);
@@ -81,7 +81,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         if (!pipelineCategories.isEmpty() || (tjp!=null && tjp.getThrottleEnabled())) {
             CauseOfBlockage cause = canRunImpl(task, tjp, pipelineCategories);
             if (cause != null) {
-            	return cause;
+                return cause;
             }
             if (tjp != null) {
                 if (tjp.getThrottleOption().equals("project")) {
@@ -177,60 +177,60 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
         return null;
     }
-    
+
     @Nonnull
     private ThrottleMatrixProjectOptions getMatrixOptions(Task task) {
         ThrottleJobProperty tjp = getThrottleJobProperty(task);
 
         if (tjp == null){
-        	return ThrottleMatrixProjectOptions.DEFAULT;       
+                return ThrottleMatrixProjectOptions.DEFAULT;
         }
         ThrottleMatrixProjectOptions matrixOptions = tjp.getMatrixOptions();
         return matrixOptions != null ? matrixOptions : ThrottleMatrixProjectOptions.DEFAULT;
     }
-    
+
     private boolean shouldBeThrottled(@Nonnull Task task, @CheckForNull ThrottleJobProperty tjp) {
-       if (tjp == null) {
-    	   return false;
-       }
-       if (!tjp.getThrottleEnabled()) { 
-    	   return false;
-       }
-       
-       // Handle matrix options
-       ThrottleMatrixProjectOptions matrixOptions = tjp.getMatrixOptions();
-       if (matrixOptions == null) {
-    	   matrixOptions = ThrottleMatrixProjectOptions.DEFAULT;
-       }
-       if (!matrixOptions.isThrottleMatrixConfigurations() && task instanceof MatrixConfiguration) {
+        if (tjp == null) {
             return false;
-       } 
-       if (!matrixOptions.isThrottleMatrixBuilds()&& task instanceof MatrixProject) {
+        }
+        if (!tjp.getThrottleEnabled()) {
             return false;
-       }
-       
-       // Allow throttling by default
-       return true;
+        }
+
+        // Handle matrix options
+        ThrottleMatrixProjectOptions matrixOptions = tjp.getMatrixOptions();
+        if (matrixOptions == null) {
+            matrixOptions = ThrottleMatrixProjectOptions.DEFAULT;
+        }
+        if (!matrixOptions.isThrottleMatrixConfigurations() && task instanceof MatrixConfiguration) {
+            return false;
+        }
+        if (!matrixOptions.isThrottleMatrixBuilds()&& task instanceof MatrixProject) {
+            return false;
+        }
+
+        // Allow throttling by default
+        return true;
     }
 
     public CauseOfBlockage canRun(Task task, ThrottleJobProperty tjp, List<String> pipelineCategories) {
         if (Jenkins.getAuthentication() == ACL.SYSTEM) {
             return canRunImpl(task, tjp, pipelineCategories);
         }
-        
+
         // Throttle-concurrent-builds requires READ permissions for all projects.
         SecurityContext orig = SecurityContextHolder.getContext();
         NotSerilizableSecurityContext auth = new NotSerilizableSecurityContext();
         auth.setAuthentication(ACL.SYSTEM);
         SecurityContextHolder.setContext(auth);
-        
+
         try {
             return canRunImpl(task, tjp, pipelineCategories);
         } finally {
             SecurityContextHolder.setContext(orig);
         }
     }
-    
+
     private CauseOfBlockage canRunImpl(Task task, ThrottleJobProperty tjp, List<String> pipelineCategories) {
         final Jenkins jenkins = Jenkins.getActiveInstance();
         if (!shouldBeThrottled(task, tjp) && pipelineCategories.isEmpty()) {
@@ -322,7 +322,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     private boolean isAnotherBuildWithSameParametersRunningOnNode(Node node, Queue.Item item) {
         ThrottleJobProperty tjp = getThrottleJobProperty(item.task);
         if (tjp == null) {
-            // If the property has been ocasionally deleted by this call, 
+            // If the property has been ocasionally deleted by this call,
             // it does not make sense to limit the throttling by parameter.
             return false;
         }

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -342,7 +342,9 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 if (currentExecutable != null &&
                         parentTask.getOwnerTask().getName().equals(item.task.getName())) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
-                    executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
+                    if (paramsToCompare.size() > 0) {
+                        executingUnitParams = doFilterParams(paramsToCompare, executingUnitParams);
+                    }
 
                     if (executingUnitParams.containsAll(itemParams)) {
                         LOGGER.log(Level.FINE, "build (" + exec.getCurrentWorkUnit() +

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -349,6 +349,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
 
         String itemTaskName = item.task.getName();
+
         // Look at all executors of specified node => computer,
         // and what work units they are busy with (if any) - and
         // whether one of these executing units is an instance
@@ -361,6 +362,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 if (currentExecutable != null &&
                         parentTask.getOwnerTask().getName().equals(itemTaskName)) {
                     List<ParameterValue> executingUnitParams = getParametersFromWorkUnit(exec.getCurrentWorkUnit());
+
                     if (paramsToCompareSize > 0) {
                         LOGGER.log(Level.FINER, "filter executingUnitParams" +
                                 " on " + computer.getDisplayName() + "#" + exec.getNumber() +
@@ -372,7 +374,8 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                                 " executingUnitParams : " + executingUnitParams +
                                 " on " + computer.getDisplayName() + "#" + exec.getNumber() +
                                 " in build (" + exec.getCurrentWorkUnit() + ")");
-                    } // else we'll compare all params, not a subset
+                    } // if nothing filtered away, or empty list was specified,
+                      // we'll compare all params, not a subset
 
                     // An already executing work unit (of the same name) can have more
                     // parameters than the queued item, e.g. due to env injection or by
@@ -402,7 +405,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     /**
      * Filter job parameters to only include parameters used for throttling
-     * @param paramsToCompare - a list of Strings with parameter names
+     * @param paramsToCompare - a list of Strings with parameter names to compare
      * @param OriginalParams - a list of ParameterValue descendants whose name fields should match
      * @return a list of ParameterValue descendants whose name fields did match, entries copied from OriginalParams
      */

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -363,7 +363,8 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                     if (executingUnitParams.containsAll(itemParams)) {
                         LOGGER.log(Level.FINE, "build (" + exec.getCurrentWorkUnit() +
                                 ") with identical parameters (" +
-                                executingUnitParams + ") is already running " +
+                                executingUnitParams + ") as the ones in queued item (" +
+                                itemParams + ") is already running " +
                                 "on node '" + node.getDisplayName() + "'.");
                         return true;
                     }

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -26,7 +26,7 @@
     <f:optionalBlock field="limitOneJobWithMatchingParams"
                    title="${%Prevent multiple jobs with identical parameters from running concurrently}"
                    inline="true">
-    <f:entry title="${%List of parameters to check (comma- or whitespace-separated)}"
+    <f:entry title="${%List of parameters to check separated by commas or whitespaces}"
              field="paramsToUseForLimit">
     <f:textbox />
       </f:entry>

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -26,7 +26,7 @@
     <f:optionalBlock field="limitOneJobWithMatchingParams"
                    title="${%Prevent multiple jobs with identical parameters from running concurrently}"
                    inline="true">
-    <f:entry title="${%List of parameters to check (comma-separated)}"
+    <f:entry title="${%List of parameters to check (comma- or whitespace-separated)}"
              field="paramsToUseForLimit">
     <f:textbox />
       </f:entry>

--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-limitOneJobWithMatchingParams.html
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/help-limitOneJobWithMatchingParams.html
@@ -1,6 +1,6 @@
 <div>
   <p>If this box is checked, only one instance of the job with matching parameter values will be allowed to run at a given time.
   Other instances of this job with different parameter values will be allowed to run concurrently.</p>
-  <p>Optionally, provide a comma-separated list of parameters to use when comparing jobs. If blank, all parameters
+  <p>Optionally, provide a comma- or whitespace-separated list of parameters to use when comparing jobs. If blank, all parameters
     must match for a job to be limited to one running instance.</p>
 </div>

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -71,6 +71,91 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         assertEquals(expectedThrottleOption, property.getThrottleOption());
     }
 
+    public void testThrottleJob_constructor_should_parse_paramsToUseForLimit() {
+        // We just set these values but do not test much, see above for that
+        Integer expectedMaxConcurrentPerNode = anyInt();
+        Integer expectedMaxConcurrentTotal = anyInt();
+        List<String> expectedCategories = Collections.emptyList();
+        boolean expectedThrottleEnabled = anyBoolean();
+        String expectedThrottleOption = anyString();
+        boolean expectedLimitOneJobWithMatchingParams = true;
+
+        // Mix the comma and whitespace separators as commas were documented
+        // in original codebase but did not work so people must have used the
+        // whitespaces de-facto.
+        String assignedParamsToUseForLimit00 = null;
+        List<String> expectedParamsToUseForLimit00 = new ArrayList<String>();
+        String assignedParamsToUseForLimit0 = "";
+        List<String> expectedParamsToUseForLimit0 = new ArrayList<String>();
+        String assignedParamsToUseForLimit1 = "ONE_PARAM";
+        List<String> expectedParamsToUseForLimit1 = Arrays.asList("ONE_PARAM");
+        String assignedParamsToUseForLimit2 = "TWO,PARAMS";
+        List<String> expectedParamsToUseForLimit2 = Arrays.asList("TWO", "PARAMS");
+        String assignedParamsToUseForLimit3 = "THREE DIFFERENT,PARAMS";
+        List<String> expectedParamsToUseForLimit3 = Arrays.asList("DIFFERENT", "PARAMS", "THREE");
+        String assignedParamsToUseForLimit4 = "FOUR ,SOMEWHAT\t,DIFFERENT , PARAMS";
+        List<String> expectedParamsToUseForLimit4 = Arrays.asList("PARAMS", "SOMEWHAT", "FOUR", "DIFFERENT");
+        String assignedParamsToUseForLimit5 = "Multi\nline" +
+                "string,for	kicks";
+        List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "for", "linestring", "kicks");
+
+        ThrottleJobProperty property00 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit00,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property00.getParamsToCompare(), expectedParamsToUseForLimit00);
+
+        ThrottleJobProperty property0 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit0,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property0.getParamsToCompare(), expectedParamsToUseForLimit0);
+
+        ThrottleJobProperty property1 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit1,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property1.getParamsToCompare(), expectedParamsToUseForLimit1);
+
+        ThrottleJobProperty property2 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit2,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property2.getParamsToCompare(), expectedParamsToUseForLimit2);
+
+        ThrottleJobProperty property3 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit3,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property3.getParamsToCompare(), expectedParamsToUseForLimit3);
+
+        ThrottleJobProperty property4 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit4,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property4.getParamsToCompare(), expectedParamsToUseForLimit4);
+
+        ThrottleJobProperty property5 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit5,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property5.getParamsToCompare(), expectedParamsToUseForLimit5);
+    }
+
     public void testThrottleJob_should_copy_categories_to_concurrency_safe_list() {
         final String category = anyString();
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -86,15 +86,27 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         // Note that the data type of paramsToUseForLimit is a List (ordered)
         // so in the test we expect it as such. Production code seems to use
         // it as an unordered set as suffices for filtering, however.
-        // (0*) Null and empty string inputs should result in an empty list object
+        // (0*) Null and empty string inputs should result in an empty list
+        // object; surrounding whitespace should be truncated so a non-empty
+        // input made of just separators is effectively empty for us too.
         String assignedParamsToUseForLimit00 = null;
         List<String> expectedParamsToUseForLimit00 = new ArrayList<String>();
         String assignedParamsToUseForLimit0 = "";
         List<String> expectedParamsToUseForLimit0 = new ArrayList<String>();
+        String assignedParamsToUseForLimit0a = " ";
+        List<String> expectedParamsToUseForLimit0a = new ArrayList<String>();
+        String assignedParamsToUseForLimit0b = " , ";
+        List<String> expectedParamsToUseForLimit0b = new ArrayList<String>();
+        String assignedParamsToUseForLimit0c = " ,,,  \n";
+        List<String> expectedParamsToUseForLimit0c = new ArrayList<String>();
         // (1) One buildarg name listed in input becomes the only one string
-        // in the list
+        // in the list; surrounding whitespace should be truncated
         String assignedParamsToUseForLimit1 = "ONE_PARAM";
         List<String> expectedParamsToUseForLimit1 = Arrays.asList("ONE_PARAM");
+        String assignedParamsToUseForLimit1a = " ONE_PARAM";
+        List<String> expectedParamsToUseForLimit1a = Arrays.asList("ONE_PARAM");
+        String assignedParamsToUseForLimit1b = " ONE_PARAM\n";
+        List<String> expectedParamsToUseForLimit1b = Arrays.asList("ONE_PARAM");
         // (2) Two buildarg names listed in input become two strings in the list
         String assignedParamsToUseForLimit2 = "TWO,PARAMS";
         List<String> expectedParamsToUseForLimit2 = Arrays.asList("TWO", "PARAMS");
@@ -129,6 +141,30 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 ThrottleMatrixProjectOptions.DEFAULT);
         assertEquals(property0.getParamsToCompare(), expectedParamsToUseForLimit0);
 
+        ThrottleJobProperty property0a = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit0a,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property0a.getParamsToCompare(), expectedParamsToUseForLimit0a);
+
+        ThrottleJobProperty property0b = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit0b,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property0b.getParamsToCompare(), expectedParamsToUseForLimit0b);
+
+        ThrottleJobProperty property0c = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit0c,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property0c.getParamsToCompare(), expectedParamsToUseForLimit0c);
+
         ThrottleJobProperty property1 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
                 expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
@@ -136,6 +172,22 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 assignedParamsToUseForLimit1,
                 ThrottleMatrixProjectOptions.DEFAULT);
         assertEquals(property1.getParamsToCompare(), expectedParamsToUseForLimit1);
+
+        ThrottleJobProperty property1a = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit1a,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property1a.getParamsToCompare(), expectedParamsToUseForLimit1a);
+
+        ThrottleJobProperty property1b = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
+                expectedMaxConcurrentTotal,
+                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
+                expectedLimitOneJobWithMatchingParams,
+                assignedParamsToUseForLimit1b,
+                ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(property1b.getParamsToCompare(), expectedParamsToUseForLimit1b);
 
         ThrottleJobProperty property2 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -131,7 +131,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit00,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property00.getParamsToCompare(), expectedParamsToUseForLimit00);
+        assertEquals(expectedParamsToUseForLimit00, property00.getParamsToCompare());
 
         ThrottleJobProperty property0 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -139,7 +139,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit0,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property0.getParamsToCompare(), expectedParamsToUseForLimit0);
+        assertEquals(expectedParamsToUseForLimit0, property0.getParamsToCompare());
 
         ThrottleJobProperty property0a = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -147,7 +147,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit0a,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property0a.getParamsToCompare(), expectedParamsToUseForLimit0a);
+        assertEquals(expectedParamsToUseForLimit0a, property0a.getParamsToCompare());
 
         ThrottleJobProperty property0b = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -155,7 +155,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit0b,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property0b.getParamsToCompare(), expectedParamsToUseForLimit0b);
+        assertEquals(expectedParamsToUseForLimit0b, property0b.getParamsToCompare());
 
         ThrottleJobProperty property0c = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -163,7 +163,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit0c,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property0c.getParamsToCompare(), expectedParamsToUseForLimit0c);
+        assertEquals(expectedParamsToUseForLimit0c, property0c.getParamsToCompare());
 
         ThrottleJobProperty property1 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -171,7 +171,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit1,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property1.getParamsToCompare(), expectedParamsToUseForLimit1);
+        assertEquals(expectedParamsToUseForLimit1, property1.getParamsToCompare());
 
         ThrottleJobProperty property1a = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -179,7 +179,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit1a,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property1a.getParamsToCompare(), expectedParamsToUseForLimit1a);
+        assertEquals(expectedParamsToUseForLimit1a, property1a.getParamsToCompare());
 
         ThrottleJobProperty property1b = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -187,7 +187,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit1b,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property1b.getParamsToCompare(), expectedParamsToUseForLimit1b);
+        assertEquals(expectedParamsToUseForLimit1b, property1b.getParamsToCompare());
 
         ThrottleJobProperty property2 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -195,7 +195,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit2,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property2.getParamsToCompare(), expectedParamsToUseForLimit2);
+        assertEquals(expectedParamsToUseForLimit2, property2.getParamsToCompare());
 
         ThrottleJobProperty property3 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -203,7 +203,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit3,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property3.getParamsToCompare(), expectedParamsToUseForLimit3);
+        assertEquals(expectedParamsToUseForLimit3, property3.getParamsToCompare());
 
         ThrottleJobProperty property4 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -211,7 +211,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit4,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property4.getParamsToCompare(), expectedParamsToUseForLimit4);
+        assertEquals(expectedParamsToUseForLimit4, property4.getParamsToCompare());
 
         ThrottleJobProperty property5 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,
@@ -219,7 +219,7 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
                 expectedLimitOneJobWithMatchingParams,
                 assignedParamsToUseForLimit5,
                 ThrottleMatrixProjectOptions.DEFAULT);
-        assertEquals(property5.getParamsToCompare(), expectedParamsToUseForLimit5);
+        assertEquals(expectedParamsToUseForLimit5, property5.getParamsToCompare());
     }
 
     public void testThrottleJob_should_copy_categories_to_concurrency_safe_list() {

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -83,6 +83,9 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         // Mix the comma and whitespace separators as commas were documented
         // in original codebase but did not work so people must have used the
         // whitespaces de-facto.
+        // Note that the data type of paramsToUseForLimit is a List (ordered)
+        // so in the test we expect it as such. Production code seems to use
+        // it as an unordered set as suffices for filtering, however.
         String assignedParamsToUseForLimit00 = null;
         List<String> expectedParamsToUseForLimit00 = new ArrayList<String>();
         String assignedParamsToUseForLimit0 = "";
@@ -92,12 +95,12 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         String assignedParamsToUseForLimit2 = "TWO,PARAMS";
         List<String> expectedParamsToUseForLimit2 = Arrays.asList("TWO", "PARAMS");
         String assignedParamsToUseForLimit3 = "THREE DIFFERENT,PARAMS";
-        List<String> expectedParamsToUseForLimit3 = Arrays.asList("DIFFERENT", "PARAMS", "THREE");
+        List<String> expectedParamsToUseForLimit3 = Arrays.asList("THREE", "DIFFERENT", "PARAMS");
         String assignedParamsToUseForLimit4 = "FOUR ,SOMEWHAT\t,DIFFERENT , PARAMS";
-        List<String> expectedParamsToUseForLimit4 = Arrays.asList("PARAMS", "SOMEWHAT", "FOUR", "DIFFERENT");
+        List<String> expectedParamsToUseForLimit4 = Arrays.asList("FOUR", "SOMEWHAT", "DIFFERENT", "PARAMS");
         String assignedParamsToUseForLimit5 = "Multi\nline" +
                 "string,for	kicks";
-        List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "for", "linestring", "kicks");
+        List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "linestring", "for", "kicks");
 
         ThrottleJobProperty property00 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -200,7 +200,8 @@ public class ThrottleJobPropertyTest {
     }
 
     @Test
-    public void testThrottleJob_constructor_should_parse_paramsToUseForLimit() {
+    @WithoutJenkins
+    public void testThrottleJobConstructorShouldParseParamsToUseForLimit() {
         // We just set these values but do not test much, see above for that
         Integer expectedMaxConcurrentPerNode = anyInt();
         Integer expectedMaxConcurrentTotal = anyInt();

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -86,21 +86,32 @@ public class ThrottleJobPropertyTest extends HudsonTestCase {
         // Note that the data type of paramsToUseForLimit is a List (ordered)
         // so in the test we expect it as such. Production code seems to use
         // it as an unordered set as suffices for filtering, however.
+        // (0*) Null and empty string inputs should result in an empty list object
         String assignedParamsToUseForLimit00 = null;
         List<String> expectedParamsToUseForLimit00 = new ArrayList<String>();
         String assignedParamsToUseForLimit0 = "";
         List<String> expectedParamsToUseForLimit0 = new ArrayList<String>();
+        // (1) One buildarg name listed in input becomes the only one string
+        // in the list
         String assignedParamsToUseForLimit1 = "ONE_PARAM";
         List<String> expectedParamsToUseForLimit1 = Arrays.asList("ONE_PARAM");
+        // (2) Two buildarg names listed in input become two strings in the list
         String assignedParamsToUseForLimit2 = "TWO,PARAMS";
         List<String> expectedParamsToUseForLimit2 = Arrays.asList("TWO", "PARAMS");
+        // (3) Different separators handled the same
         String assignedParamsToUseForLimit3 = "THREE DIFFERENT,PARAMS";
         List<String> expectedParamsToUseForLimit3 = Arrays.asList("THREE", "DIFFERENT", "PARAMS");
+        // (4) Several separating tokens together must go away as one - we want
+        // no empties in the resulting list
         String assignedParamsToUseForLimit4 = "FOUR ,SOMEWHAT\t,DIFFERENT , PARAMS";
         List<String> expectedParamsToUseForLimit4 = Arrays.asList("FOUR", "SOMEWHAT", "DIFFERENT", "PARAMS");
+        // (5) Java does not really have multilines, but still... note that
+        // if any whitespace should be there in the carry-over of string
+        // representation, it is the coder's responsibility to ensure some.
         String assignedParamsToUseForLimit5 = "Multi\nline" +
-                "string,for	kicks";
-        List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "linestring", "for", "kicks");
+                "string,for	kicks\n" +
+                "EOL";
+        List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "linestring", "for", "kicks", "EOL");
 
         ThrottleJobProperty property00 = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
                 expectedMaxConcurrentTotal,


### PR DESCRIPTION
So far posting for review and sanity check.

We have an issue that several jobs are configured with a comma-separated list of parameters to check against for throttling (e.g. that we do not run tests against the same host and port in parallel), and expect that tests with other combinations of parameters would run and not stay in queue. We see this expected behavior in jobs that do not specify a list of parameters, and I think in those that specify just one.

So far we see instead that comparison is done to an empty array when we specify a list of parameters, as implemented in #38:
````
Jun 28, 2019 5:52:44 PM FINE hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher isAnotherBuildWithSameParametersRunningOnNode

build (hudson.model.queue.WorkUnit@5e3c8658[work=selenium]) with identical parameters ([]) is already running.
````
and so only one instance of a job is running and others (tests against different hosts) are queued.

This PR starts out as a bit of documentation and instrumentation to understand the problem, and I hope would end up with a solution too :)