### PR TITLE
Update plugin parent POM to latest version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ THE SOFTWARE.
   <artifactId>throttle-concurrents</artifactId>
   <packaging>hpi</packaging>
   <name>Jenkins Throttle Concurrent Builds Plug-in</name>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <url>https://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
   <description>Plugin to throttle the number of concurrent builds of a single job per node.</description>
   
@@ -45,6 +45,8 @@ THE SOFTWARE.
   </licenses>
     
   <properties>
+    <revision>2.0.2</revision>
+    <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
     <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
@@ -90,7 +92,7 @@ THE SOFTWARE.
     <connection>scm:git:git://github.com/jenkinsci/throttle-concurrent-builds-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/throttle-concurrent-builds-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,15 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.26</version>
+    <version>3.52</version>
+    <relativePath />
   </parent>
 
   <artifactId>throttle-concurrents</artifactId>
   <packaging>hpi</packaging>
   <name>Jenkins Throttle Concurrent Builds Plug-in</name>
   <version>2.0.2-SNAPSHOT</version>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Throttle+Concurrent+Builds+Plugin</url>
+  <url>https://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
   <description>Plugin to throttle the number of concurrent builds of a single job per node.</description>
   
   <licenses>
@@ -44,11 +45,10 @@ THE SOFTWARE.
   </licenses>
     
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
-    <java.level>6</java.level>
-    <!--TODO: do not fail on errors-->
-    <findbugs.failOnError>false</findbugs.failOnError>
-    <java.level>7</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
+    <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
+    <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
   </properties>
 
   <developers>
@@ -56,6 +56,12 @@ THE SOFTWARE.
       <id>abayer</id>
       <name>Andrew Bayer</name>
       <email>andrew.bayer@gmail.com</email>
+      <timezone>-8</timezone>
+    </developer>
+    <developer>
+      <id>basil</id>
+      <name>Basil Crow</name>
+      <email>me@basilcrow.com</email>
       <timezone>-8</timezone>
     </developer>
     <developer>
@@ -83,7 +89,7 @@ THE SOFTWARE.
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/throttle-concurrent-builds-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/throttle-concurrent-builds-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
+    <url>https://github.com/jenkinsci/throttle-concurrent-builds-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -94,13 +100,23 @@ THE SOFTWARE.
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>script-security</artifactId>
+                <version>1.25</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
+                <artifactId>icon-set</artifactId>
+                <version>2.0.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
-            <type>jar</type>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
@@ -144,13 +160,13 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.28</version>
+            <version>${workflow-cps-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.28</version>
+            <version>${workflow-cps-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -175,12 +191,12 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13</version>
+            <version>${workflow-support-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.13</version>
+            <version>${workflow-support-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.52</version>
+    <version>3.51</version>
     <relativePath />
   </parent>
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/testutils/HtmlUnitHelper.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/testutils/HtmlUnitHelper.java
@@ -25,7 +25,7 @@ package hudson.plugins.throttleconcurrents.testutils;
 
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.List;
 import org.kohsuke.accmod.Restricted;
@@ -50,8 +50,8 @@ public class HtmlUnitHelper {
      * @param xpath Xpath for buttons search
      * @return List of discovered buttons
      */
-    @NonNull
-    public static List<HtmlButton> getButtonsByXPath(@NonNull HtmlForm form, @NonNull String xpath) {
+    @Nonnull
+    public static List<HtmlButton> getButtonsByXPath(@Nonnull HtmlForm form, @Nonnull String xpath) {
         List<?> buttons = form.getByXPath(xpath);
         List<HtmlButton> res = new ArrayList<>(buttons.size());
         for(Object buttonCandidate: buttons) {


### PR DESCRIPTION
This is the first of a series of changes to get this plugin's builds and tests into decent shape as described in jenkins-infra/repository-permissions-updater#1325. After this change is merged, I plan to update the `Jenkinsfile` to use `buildPlugin.recommendedConfigurations()`. After that, I plan to clean up and improve the tests. And after that, I plan to merge the fixes for jenkinsci/throttle-concurrent-builds-plugin#57 and jenkinsci/throttle-concurrent-builds-plugin#58.

This PR implements the following:

- Updates the plugin parent POM to [the latest version](https://github.com/jenkinsci/plugin-pom/releases).
- Sets the POM URL to the plugin's GitHub URL, which is the [current recommended best practice](https://github.com/jenkinsci/archetypes/blob/8a49c0c784267d8baf3841199fa4292aad18225a/empty-plugin/src/main/resources/archetype-resources/pom.xml#L26).
- Sets the minimum Jenkins version to 2.60.3 and the Java level to 8, which is the lowest currently supported version of Java for Jenkins.
- Makes `workflow-cps-plugin` and `workflow-support-plugin` versions into properties to reduce code duplication.
- Updates the developers list in the POM.
- Adds a `dependencyManagement` section to the POM. This allows us to fix the Mvaen Enforcer warnings that are encountered when upgrading to the latest plugin parent POM.
- Replaces the non-standard `edu.umd.cs.findbugs.annotations.NonNull` annotation with the standard `javax.annotation.Nonnull` annotation. This allows us to remove the explicit `com.google.code.findbugs:jsr305` dependency from the POM.
- Converts `ThrottleIntegrationTest` from the deprecated `HudsonTestCase` to the non-deprecated `JenkinsRule`. This allows us to fix a test failure that is encountered when upgrading to the latest plugin parent POM and Jenkins test harness.
- Incrementalifies the plugin.