### PR TITLE
Add recent LTS line to CI build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,9 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useAci: true)
+buildPlugin(useAci: true, configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.164.1", javaLevel: "8" ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@ THE SOFTWARE.
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.60.3</jenkins.version>
     <java.level>8</java.level>
-    <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
-    <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
+    <workflow-cps-plugin.version>2.42</workflow-cps-plugin.version>
+    <workflow-support-plugin.version>2.16</workflow-support-plugin.version>
   </properties>
 
   <developers>
@@ -108,12 +108,7 @@ THE SOFTWARE.
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1.25</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
-                <artifactId>icon-set</artifactId>
-                <version>2.0.3</version>
+                <version>1.36</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -122,35 +117,35 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.8</version>
+            <version>1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.12</version>
+            <version>2.24</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.7</version>
+            <version>2.13</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>2.13</version>
         </dependency>
 
         <!-- Dependencies for test -->
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>cloudbees-folder</artifactId>
-          <version>6.0.2</version>
+          <version>6.2.0</version>
           <scope>test</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>matrix-auth</artifactId>
-          <version>1.4</version>
+          <version>2.1</version>
           <scope>test</scope>
         </dependency>
         <dependency>
@@ -175,19 +170,19 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>2.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>junit</artifactId>
-            <version>1.15</version>
+            <version>1.20</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I plan to add some new tests to this plugin soon. Before doing so, it would be good to ensure that these tests get run on both the minimum supported version of Jenkins (2.60.3) as well as a more recent LTS version. To that end, I am adding test runs for Jenkins 2.164.1 on Java 8 in addition to the tests we are already running for Jenkins 2.60.3 on Java 8.

While I was here, I updated some dependencies to _slightly_ newer versions. The existing dependencies were from early 2017. I updated these to versions from later in 2017. This makes testing more realistic, as the tests will now be running against a slightly more recent set of plugins, which better aligns with how users are actually running Jenkins. I didn't upgrade any plugins past the 2017 versions in order to minimize risk and maintain the broadest degree of compatibility for this plugin for now. Later on, after 2.0.2 is released, we can consider doing further updates.

I considered using `buildPlugin.recommendedConfigurations()`, but that requires adding Java 11 tests to the plugin. That would require upgrading `workflow-support` to version 3.0 or later, which was released in January 2019. I deemed this too risky for 2.0.2. I will consider doing this upgrade and using `buildPlugin.recommendedConfigurations()` for 2.0.3. For now, the current change gets us halfway there by adding tests for Jenkins 2.164.1 on Java 8 (which is better than the current status quo).