### PR TITLE
Test cleanup

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
@@ -44,7 +44,7 @@ import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SleepBuilder;
 
@@ -180,7 +180,7 @@ public class ThrottleIntegrationTest {
         assertEquals(1, waterMark.getExecutorWaterMark());
     }
     
-    @Bug(25326)
+    @Issue("JENKINS-25326")
     @Test
     public void testThrottlingWithCategoryInFolder() throws Exception {
         final String category = "category";

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -2,6 +2,7 @@ package hudson.plugins.throttleconcurrents;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -103,8 +104,10 @@ public class ThrottleJobPropertyTest {
 
         List<String> storedCategories = property.getCategories();
         assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
-        assertTrue("expected unsafe list to be converted to a converted to some other concurrency-safe impl",
-                unsafeList != storedCategories);
+        assertNotSame(
+                "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
+                unsafeList,
+                storedCategories);
         assertTrue(storedCategories instanceof CopyOnWriteArrayList);
     }
 
@@ -140,8 +143,10 @@ public class ThrottleJobPropertyTest {
         descriptor.setCategories(unsafeList);
         List<ThrottleJobProperty.ThrottleCategory> storedCategories = descriptor.getCategories();
         assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
-        assertTrue("expected unsafe list to be converted to a converted to some other concurrency-safe impl",
-                unsafeList != storedCategories);
+        assertNotSame(
+                "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
+                unsafeList,
+                storedCategories);
         assertTrue(storedCategories instanceof CopyOnWriteArrayList);
     }
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -13,7 +13,7 @@ import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.util.*;
@@ -27,7 +27,7 @@ public class ThrottleJobPropertyTest {
     @Rule
     public JenkinsRule r = new JenkinsRule();
 
-    @Bug(19623)
+    @Issue("JENKINS-19623")
     @Test
     public void testGetCategoryProjects() throws Exception {
         String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -16,6 +16,10 @@
  */
 package hudson.plugins.throttleconcurrents;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.gargoylesoftware.htmlunit.ElementNotFoundException;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlElement;
@@ -37,7 +41,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 /**
  * This class initiates the testing of {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher}.<br>
@@ -45,8 +51,7 @@ import org.jvnet.hudson.test.HudsonTestCase;
  * -Happens to test {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher#getMaxConcurrentPerNodeBasedOnMatchingLabels(hudson.model.Node, hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory, int)}.
  * @author marco.miller@ericsson.com
  */
-public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
-{
+public class ThrottleQueueTaskDispatcherTest {
     private static final String buttonsXPath = "//button[@tabindex='0']";
     private static final String configFormName = "config";
     private static final String configUrlSuffix = "configure";
@@ -73,20 +78,15 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     private static final int someCategoryWideMaxConcurrentPerNode = 1;
     private static final int greaterCategoryWideMaxConcurrentPerNode = configureOneMaxLabelPair+1;
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
     /**
      * @throws ExecutionException upon Jenkins project build scheduling issue.
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
+    @Test
     public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPair()
     throws ExecutionException, InterruptedException, IOException
     {
@@ -102,6 +102,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
+    @Test
     public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPairs()
     throws ExecutionException, InterruptedException, IOException
     {
@@ -117,6 +118,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
+    @Test
     public void testShouldConsiderTaskAsBlockableStillUponMatchingLabelPairWithLowestMax()
     throws ExecutionException, InterruptedException, IOException
     {
@@ -132,6 +134,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
+    @Test
     public void testShouldConsiderTaskAsBuildableStillUponMismatchingMaxLabelPairs()
     throws ExecutionException, InterruptedException, IOException
     {
@@ -147,6 +150,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
+    @Test
     public void testShouldConsiderTaskAsBuildableStillUponNoNodeLabel()
     throws ExecutionException, InterruptedException, IOException
     {
@@ -177,7 +181,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
         }
         configureGlobalThrottling(testCategoryLabel, targetedPairNumber, maxConcurrentPerNode);
 
-        FreeStyleProject project = createFreeStyleProject();
+        FreeStyleProject project = r.createFreeStyleProject();
         configureJobThrottling(project);
         String logger = configureLogger();
         project.scheduleBuild2(0).get();
@@ -196,8 +200,8 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     private void configureGlobalThrottling(String labelRoot, int numberOfPairs, int maxConcurrentPerNode)
     throws InterruptedException, IOException, MalformedURLException
     {
-        URL url = new URL(getURL()+configUrlSuffix);
-        HtmlPage page = createWebClient().getPage(url);
+        URL url = new URL(r.getURL()+configUrlSuffix);
+        HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
         List<HtmlButton> buttons = HtmlUnitHelper.getButtonsByXPath(form, parentXPath+buttonsXPath);
         String buttonText = "Add Category";
@@ -257,8 +261,8 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     private void configureJobThrottling(FreeStyleProject project)
     throws IOException, MalformedURLException
     {
-        URL url = new URL(getURL()+project.getUrl()+configUrlSuffix);
-        HtmlPage page = createWebClient().getPage(url);
+        URL url = new URL(r.getURL()+project.getUrl()+configUrlSuffix);
+        HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
         List<HtmlButton> buttons = HtmlUnitHelper.getButtonsByXPath(form, buttonsXPath);
         String buttonText = saveButtonText;
@@ -290,8 +294,8 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     private void configureNewNodeWithLabel(String label)
     throws IOException, MalformedURLException
     {
-        URL url = new URL(getURL()+"computer/new");
-        HtmlPage page = createWebClient().getPage(url);
+        URL url = new URL(r.getURL()+"computer/new");
+        HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName("createItem");
 
         HtmlInput input = form.getInputByName("name");
@@ -342,9 +346,9 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     throws IOException, MalformedURLException
     {
         String logger = ThrottleQueueTaskDispatcher.class.getName();
-        jenkins.getLog().doNewLogRecorder(logger);
-        URL url = new URL(getURL()+logUrlPrefix+logger+"/"+configUrlSuffix);
-        HtmlPage page = createWebClient().getPage(url);
+        r.jenkins.getLog().doNewLogRecorder(logger);
+        URL url = new URL(r.getURL()+logUrlPrefix+logger+"/"+configUrlSuffix);
+        HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
         List<HtmlButton> buttons = HtmlUnitHelper.getButtonsByXPath(form, buttonsXPath);
         String buttonText = "Add";
@@ -412,7 +416,7 @@ public class ThrottleQueueTaskDispatcherTest extends HudsonTestCase
     private HtmlPage getLoggerPage(String logger)
     throws IOException, MalformedURLException
     {
-        URL url = new URL(getURL()+logUrlPrefix+logger);
-        return createWebClient().getPage(url);
+        URL url = new URL(r.getURL()+logUrlPrefix+logger);
+        return r.createWebClient().getPage(url);
     }
 }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -82,7 +82,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void onePerNode() throws Exception {
+    public void onePerNode() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -118,7 +118,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void duplicateCategories() throws Exception {
+    public void duplicateCategories() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -138,7 +138,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void undefinedCategories() throws Exception {
+    public void undefinedCategories() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -155,7 +155,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void multipleCategories() throws Exception {
+    public void multipleCategories() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -208,7 +208,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void onePerNodeParallel() throws Exception {
+    public void onePerNodeParallel() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -267,7 +267,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void twoTotal() throws Exception {
+    public void twoTotal() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -317,7 +317,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void interopWithFreestyle() throws Exception {
+    public void interopWithFreestyle() {
         final Semaphore semaphore = new Semaphore(1);
 
         story.addStep(new Statement() {
@@ -428,7 +428,7 @@ public class ThrottleStepTest {
     }
 
     @Test
-    public void snippetizer() throws Exception {
+    public void snippetizer() {
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {


### PR DESCRIPTION
Now that the plugin POM is up-to-date and the CI system is running tests on both Jenkins 2.60.3 and Jenkins 2.164.1 (a recent LTS release), let's start cleaning up the tests in preparation for some future changes. This will give us a solid baseline to measure future changes against.

This PR makes the following changes to tests:

- Migrate from deprecated `HudsonTestCase` to `JenkinsRule`
- Migrate from deprecated `@Bug` to `@Issue`
- Remove unnecessary `throws` declarations in tests
- Simplify JUnit assertions