### PR TITLE
Fix flakiness in ThrottleStep#onePerNodeParallel

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -246,15 +246,15 @@ public class ThrottleStepTest {
                 assertEquals(1, first.countBusy());
                 assertEquals(1, second.countBusy());
                 SemaphoreStep.success("wait-first-branch-b-job/1", null);
-                SemaphoreStep.waitForStart("wait-second-branch-a-job/1", run1);
+                SemaphoreStep.waitForStart("wait-second-branch-a-job/1", run2);
                 assertEquals(1, first.countBusy());
                 assertEquals(1, second.countBusy());
                 SemaphoreStep.success("wait-first-branch-c-job/1", null);
-                SemaphoreStep.waitForStart("wait-second-branch-b-job/1", run1);
+                SemaphoreStep.waitForStart("wait-second-branch-b-job/1", run2);
                 assertEquals(1, first.countBusy());
                 assertEquals(1, second.countBusy());
                 SemaphoreStep.success("wait-second-branch-a-job/1", null);
-                SemaphoreStep.waitForStart("wait-second-branch-c-job/1", run1);
+                SemaphoreStep.waitForStart("wait-second-branch-c-job/1", run2);
                 assertEquals(1, first.countBusy());
                 assertEquals(1, second.countBusy());
                 SemaphoreStep.success("wait-second-branch-b-job/1", null);

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -125,7 +125,7 @@ public class ThrottleStepTest {
                 setupAgentsAndCategories();
 
                 WorkflowJob j = story.j.jenkins.createProject(WorkflowJob.class, "first-job");
-                j.setDefinition(new CpsFlowDefinition("throttle(['" + ONE_PER_NODE + "', '" + ONE_PER_NODE +"']) { echo 'Hello' }", false));
+                j.setDefinition(new CpsFlowDefinition("throttle(['" + ONE_PER_NODE + "', '" + ONE_PER_NODE +"']) { echo 'Hello' }", true));
 
                 WorkflowRun b = j.scheduleBuild2(0).waitForStart();
 
@@ -143,7 +143,7 @@ public class ThrottleStepTest {
             @Override
             public void evaluate() throws Throwable {
                 WorkflowJob j = story.j.jenkins.createProject(WorkflowJob.class, "first-job");
-                j.setDefinition(new CpsFlowDefinition("throttle(['undefined', 'also-undefined']) { echo 'Hello' }", false));
+                j.setDefinition(new CpsFlowDefinition("throttle(['undefined', 'also-undefined']) { echo 'Hello' }", true));
 
                 WorkflowRun b = j.scheduleBuild2(0).waitForStart();
 
@@ -218,7 +218,7 @@ public class ThrottleStepTest {
                         "  a: { " + getThrottleScript("first-branch-a", ONE_PER_NODE, "on-agent") + " },\n" +
                         "  b: { " + getThrottleScript("first-branch-b", ONE_PER_NODE, "on-agent") + " },\n" +
                         "  c: { " + getThrottleScript("first-branch-c", ONE_PER_NODE, "on-agent") + " }\n" +
-                        ")\n", false));
+                        ")\n", true));
 
                 WorkflowRun run1 = firstJob.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait-first-branch-a-job/1", run1);
@@ -229,7 +229,7 @@ public class ThrottleStepTest {
                         "  a: { " + getThrottleScript("second-branch-a", ONE_PER_NODE, "on-agent") + " },\n" +
                         "  b: { " + getThrottleScript("second-branch-b", ONE_PER_NODE, "on-agent") + " },\n" +
                         "  c: { " + getThrottleScript("second-branch-c", ONE_PER_NODE, "on-agent") + " }\n" +
-                        ")\n", false));
+                        ")\n", true));
 
                 WorkflowRun run2 = secondJob.scheduleBuild2(0).waitForStart();
 
@@ -404,9 +404,7 @@ public class ThrottleStepTest {
     }
 
     private CpsFlowDefinition getJobFlow(String jobName, List<String> categories, String label) {
-        // This should be sandbox:true, but when I do that, I get org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object
-        // And I cannot figure out why. So for now...
-        return new CpsFlowDefinition(getThrottleScript(jobName, categories, label), false);
+        return new CpsFlowDefinition(getThrottleScript(jobName, categories, label), true);
     }
 
     private String getThrottleScript(String jobName, String category, String label) {


### PR DESCRIPTION
### Problem

`ThrottleStep#onePerNodeParallel` has been frequently observed to flake as follows:

```
13:58:54  [ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 144.794 s <<< FAILURE! - in hudson.plugins.throttleconcurrents.ThrottleStepTest
13:58:54  [ERROR] onePerNodeParallel(hudson.plugins.throttleconcurrents.ThrottleStepTest)  Time elapsed: 23.362 s  <<< FAILURE!
13:58:54  java.lang.AssertionError:
13:58:54  Started
13:58:54  [Pipeline] parallel
13:58:54  [Pipeline] [a] { (Branch: a)
13:58:54  [Pipeline] [b] { (Branch: b)
13:58:54  [Pipeline] [c] { (Branch: c)
13:58:54  [Pipeline] [a] throttle
13:58:54  [Pipeline] [a] {
13:58:54  [Pipeline] [b] throttle
13:58:54  [Pipeline] [b] {
13:58:54  [Pipeline] [c] throttle
13:58:54  [Pipeline] [c] {
13:58:54  [Pipeline] [a] echo
13:58:54  [a] hi there
13:58:54  [Pipeline] [a] node
13:58:54  [Pipeline] [b] echo
13:58:54  [b] hi there
13:58:54  [Pipeline] [b] node
13:58:54  [Pipeline] [c] echo
13:58:54  [c] hi there
13:58:54  [Pipeline] [c] node
13:58:54  [a] Running on second-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3787017647470886153\workspace\first-job
13:58:54  [Pipeline] [a] {
13:58:54  [Pipeline] [a] semaphore
13:58:54  [b] Running on first-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3742662384626967559\workspace\first-job
13:58:54  [Pipeline] [b] {
13:58:54  [Pipeline] [b] semaphore
13:58:54  [c] Still waiting to schedule task
13:58:54  [c] Already running 1 builds on node; Jenkins doesn’t have label on-agent
13:58:54  [Pipeline] [a] }
13:58:54  [c] Running on second-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3787017647470886153\workspace\first-job
13:58:54  [Pipeline] [a] // node
13:58:54  [Pipeline] [c] {
13:58:54  [Pipeline] [a] }
13:58:54  [Pipeline] [c] semaphore
13:58:54  [Pipeline] [a] // throttle
13:58:54  [Pipeline] [a] }
13:58:54  [Pipeline] [b] }
13:58:54  [Pipeline] [b] // node
13:58:54  [Pipeline] [b] }
13:58:54  [Pipeline] [b] // throttle
13:58:54  [Pipeline] [b] }
13:58:54  [Pipeline] [c] }
13:58:54  [Pipeline] [c] // node
13:58:54  [Pipeline] [c] }
13:58:54  [Pipeline] [c] // throttle
13:58:54  [Pipeline] [c] }
13:58:54  [Pipeline] // parallel
13:58:54  [Pipeline] End of Pipeline
13:58:54  Finished: SUCCESS
13:58:54
13:58:54        at org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.waitForStart(SemaphoreStep.java:144)
13:58:54        at hudson.plugins.throttleconcurrents.ThrottleStepTest$5.evaluate(ThrottleStepTest.java:257)
13:58:54        at org.jvnet.hudson.test.RestartableJenkinsRule$6.evaluate(RestartableJenkinsRule.java:272)
13:58:54        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:598)
13:58:54        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
13:58:54        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
13:58:54        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
13:58:54        at java.lang.Thread.run(Thread.java:748)
13:58:54
13:58:55  [INFO]
13:58:55  [INFO] Results:
13:58:55  [INFO]
13:58:55  [WARNING] Flakes:
13:58:55  [WARNING] hudson.plugins.throttleconcurrents.ThrottleStepTest.onePerNodeParallel(hudson.plugins.throttleconcurrents.ThrottleStepTest)
13:58:55  [ERROR]   Run 1: ThrottleStepTest.onePerNodeParallel Started
13:58:55  [Pipeline] parallel
13:58:55  [Pipeline] [a] { (Branch: a)
13:58:55  [Pipeline] [b] { (Branch: b)
13:58:55  [Pipeline] [c] { (Branch: c)
13:58:55  [Pipeline] [a] throttle
13:58:55  [Pipeline] [a] {
13:58:55  [Pipeline] [b] throttle
13:58:55  [Pipeline] [b] {
13:58:55  [Pipeline] [c] throttle
13:58:55  [Pipeline] [c] {
13:58:55  [Pipeline] [a] echo
13:58:55  [a] hi there
13:58:55  [Pipeline] [a] node
13:58:55  [Pipeline] [b] echo
13:58:55  [b] hi there
13:58:55  [Pipeline] [b] node
13:58:55  [Pipeline] [c] echo
13:58:55  [c] hi there
13:58:55  [Pipeline] [c] node
13:58:55  [a] Running on second-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3787017647470886153\workspace\first-job
13:58:55  [Pipeline] [a] {
13:58:55  [Pipeline] [a] semaphore
13:58:55  [b] Running on first-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3742662384626967559\workspace\first-job
13:58:55  [Pipeline] [b] {
13:58:55  [Pipeline] [b] semaphore
13:58:55  [c] Still waiting to schedule task
13:58:55  [c] Already running 1 builds on node; Jenkins doesn’t have label on-agent
13:58:55  [Pipeline] [a] }
13:58:55  [c] Running on second-agent in C:\Jenkins\workspace\e-concurrent-builds-plugin_PR-63\target\tmp\junit3787017647470886153\workspace\first-job
13:58:55  [Pipeline] [a] // node
13:58:55  [Pipeline] [c] {
13:58:55  [Pipeline] [a] }
13:58:55  [Pipeline] [c] semaphore
13:58:55  [Pipeline] [a] // throttle
13:58:55  [Pipeline] [a] }
13:58:55  [Pipeline] [b] }
13:58:55  [Pipeline] [b] // node
13:58:55  [Pipeline] [b] }
13:58:55  [Pipeline] [b] // throttle
13:58:55  [Pipeline] [b] }
13:58:55  [Pipeline] [c] }
13:58:55  [Pipeline] [c] // node
13:58:55  [Pipeline] [c] }
13:58:55  [Pipeline] [c] // throttle
13:58:55  [Pipeline] [c] }
13:58:55  [Pipeline] // parallel
13:58:55  [Pipeline] End of Pipeline
13:58:55  Finished: SUCCESS
13:58:55
13:58:55  [INFO]   Run 2: PASS
13:58:55  [INFO]
13:58:55  [INFO]
13:58:55  [WARNING] Tests run: 36, Failures: 0, Errors: 0, Skipped: 1, Flakes: 1
```

### Evaluation

I noticed this test flakes more often on fast systems, pointing to some sort of race condition. The relevant part of the stack trace is as follows:

```
13:58:54        at org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep.waitForStart(SemaphoreStep.java:144)
13:58:54        at hudson.plugins.throttleconcurrents.ThrottleStepTest$5.evaluate(ThrottleStepTest.java:257)
```

The failing line in the test is:

```
SemaphoreStep.waitForStart("wait-second-branch-c-job/1", run1);
```

It is failing in this method in `SemaphoreStep`:

```
    public static void waitForStart(@Nonnull String k, @CheckForNull Run<?,?> b) throws IOException, InterruptedException {
        State s = State.get();
        synchronized (s) {
            while (!s.started.contains(k)) {
                if (b != null && !b.isBuilding()) {
                    throw new AssertionError(JenkinsRule.getLog(b));
                }
                s.wait(1000);
            }
        }
    }
```

The problem is we are passing the wrong run to `SemaphoreStep#waitForStart`. The run in the second argument should be the run associated with the semaphore being passed in as the first argument. However, we we were erroneously passing in a different run. This test uses two jobs, each with a different set of semaphores. So this was working by accident most of the time in that the first job happened to be building, avoiding the `AssertionError`. But if the first job happens to not be building (as was the case in the flaky runs), the `AssertionError` will be thrown.

### Solution

Pass in the correct run to `SemaphoreStep#waitForStart`.

### Testing Done

Ran the test in a loop on a fast system both with and without the fix. Without the fix, the test usually failed within 10 to 20 iterations. With the fix, the test has passed for 60 consecutive iterations.

### Bonus

Consistently use the script sandbox in `CpsFlowDefinition`s. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production.