### PR TITLE
Add more tests

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -1,21 +1,38 @@
 package hudson.plugins.throttleconcurrents;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.Iterables;
 import hudson.model.AbstractProject;
+import hudson.model.Executor;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
+import hudson.model.Node;
 import hudson.model.Queue;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.security.ACL;
 import hudson.security.AuthorizationStrategy;
+import hudson.slaves.DumbSlave;
+import hudson.slaves.RetentionStrategy;
+import hudson.util.RunList;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.support.steps.ExecutorStepExecution;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
 
 import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -23,141 +40,265 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class ThrottleJobPropertyTest {
 
     private static final String THROTTLE_OPTION_CATEGORY = "category"; // TODO move this into ThrottleJobProperty and use consistently; same for "project"
+    private static final String TWO_TOTAL = "two_total";
+
     private final Random random = new Random(System.currentTimeMillis());
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
+    @Rule public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule public TemporaryFolder firstAgentTmp = new TemporaryFolder();
+    @Rule public TemporaryFolder secondAgentTmp = new TemporaryFolder();
+
+    public void setupAgentsAndCategories() throws Exception {
+        DumbSlave firstAgent =
+                new DumbSlave(
+                        "first-agent",
+                        "dummy agent",
+                        firstAgentTmp.getRoot().getAbsolutePath(),
+                        "4",
+                        Node.Mode.NORMAL,
+                        "on-agent",
+                        story.j.createComputerLauncher(null),
+                        RetentionStrategy.NOOP,
+                        Collections.emptyList());
+
+        DumbSlave secondAgent =
+                new DumbSlave(
+                        "second-agent",
+                        "dummy agent",
+                        secondAgentTmp.getRoot().getAbsolutePath(),
+                        "4",
+                        Node.Mode.NORMAL,
+                        "on-agent",
+                        story.j.createComputerLauncher(null),
+                        RetentionStrategy.NOOP,
+                        Collections.emptyList());
+
+        story.j.jenkins.addNode(firstAgent);
+        story.j.jenkins.addNode(secondAgent);
+
+        ThrottleJobProperty.ThrottleCategory cat =
+                new ThrottleJobProperty.ThrottleCategory(TWO_TOTAL, 0, 2, null);
+
+        ThrottleJobProperty.DescriptorImpl descriptor =
+                story.j.jenkins.getDescriptorByType(ThrottleJobProperty.DescriptorImpl.class);
+        assertNotNull(descriptor);
+        descriptor.setCategories(Collections.singletonList(cat));
+
+        // The following is required for tests that restart Jenkins.
+        descriptor.save();
+    }
 
     @Issue("JENKINS-19623")
     @Test
-    public void testGetCategoryProjects() throws Exception {
-        String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names
-        FreeStyleProject p1 = r.createFreeStyleProject("p1");
-        FreeStyleProject p2 = r.createFreeStyleProject("p2");
-        p2.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha), false, THROTTLE_OPTION_CATEGORY, false, "", ThrottleMatrixProjectOptions.DEFAULT));
-        FreeStyleProject p3 = r.createFreeStyleProject("p3");
-        p3.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(alpha, beta), true, THROTTLE_OPTION_CATEGORY, false, "", ThrottleMatrixProjectOptions.DEFAULT));
-        FreeStyleProject p4 = r.createFreeStyleProject("p4");
-        p4.addProperty(new ThrottleJobProperty(1, 1, Arrays.asList(beta, gamma), true, THROTTLE_OPTION_CATEGORY, false, "", ThrottleMatrixProjectOptions.DEFAULT));
-        // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we can check jobs inside folders
-        assertProjects(alpha, p3);
-        assertProjects(beta, p3, p4);
-        assertProjects(gamma, p4);
-        assertProjects("delta");
-        p4.renameTo("p-4");
-        assertProjects(gamma, p4);
-        p4.delete();
-        assertProjects(gamma);
-        AbstractProject<?,?> p3b = r.jenkins.<AbstractProject<?,?>>copy(p3, "p3b");
-        assertProjects(beta, p3, p3b);
-        p3.removeProperty(ThrottleJobProperty.class);
-        assertProjects(beta, p3b);
+    public void testGetCategoryProjects() {
+        story.then(
+                s -> {
+                    String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names
+                    FreeStyleProject p1 = story.j.createFreeStyleProject("p1");
+                    FreeStyleProject p2 = story.j.createFreeStyleProject("p2");
+                    p2.addProperty(
+                            new ThrottleJobProperty(
+                                    1,
+                                    1,
+                                    Collections.singletonList(alpha),
+                                    false,
+                                    THROTTLE_OPTION_CATEGORY,
+                                    false,
+                                    "",
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+                    FreeStyleProject p3 = story.j.createFreeStyleProject("p3");
+                    p3.addProperty(
+                            new ThrottleJobProperty(
+                                    1,
+                                    1,
+                                    Arrays.asList(alpha, beta),
+                                    true,
+                                    THROTTLE_OPTION_CATEGORY,
+                                    false,
+                                    "",
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+                    FreeStyleProject p4 = story.j.createFreeStyleProject("p4");
+                    p4.addProperty(
+                            new ThrottleJobProperty(
+                                    1,
+                                    1,
+                                    Arrays.asList(beta, gamma),
+                                    true,
+                                    THROTTLE_OPTION_CATEGORY,
+                                    false,
+                                    "",
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+                    // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we
+                    // can check jobs inside folders
+                    assertProjects(alpha, p3);
+                    assertProjects(beta, p3, p4);
+                    assertProjects(gamma, p4);
+                    assertProjects("delta");
+                    p4.renameTo("p-4");
+                    assertProjects(gamma, p4);
+                    p4.delete();
+                    assertProjects(gamma);
+                    AbstractProject<?, ?> p3b =
+                            story.j.jenkins.<AbstractProject<?, ?>>copy(p3, "p3b");
+                    assertProjects(beta, p3, p3b);
+                    p3.removeProperty(ThrottleJobProperty.class);
+                    assertProjects(beta, p3b);
+                });
     }
 
 
 
     @Test
-    public void testToString_withNulls(){
-        ThrottleJobProperty tjp = new ThrottleJobProperty(0,0, null, false, null, false, "", ThrottleMatrixProjectOptions.DEFAULT);
-        assertNotNull(tjp.toString());
+    public void testToStringWithNulls() {
+        story.then(
+                s -> {
+                    ThrottleJobProperty tjp =
+                            new ThrottleJobProperty(
+                                    0,
+                                    0,
+                                    null,
+                                    false,
+                                    null,
+                                    false,
+                                    "",
+                                    ThrottleMatrixProjectOptions.DEFAULT);
+                    assertNotNull(tjp.toString());
+                });
     }
 
     @Test
-    public void testThrottleJob_constructor_should_store_arguments() {
-        Integer expectedMaxConcurrentPerNode = anyInt();
-        Integer expectedMaxConcurrentTotal = anyInt();
-        List<String> expectedCategories = Collections.emptyList();
-        boolean expectedThrottleEnabled = anyBoolean();
-        String expectedThrottleOption = anyString();
-        boolean expectedLimitOneJobWithMatchingParams = anyBoolean();
-        String expectedParamsToUseForLimit = anyString();
+    public void testThrottleJobConstructorShouldStoreArguments() {
+        story.then(
+                s -> {
+                    Integer expectedMaxConcurrentPerNode = anyInt();
+                    Integer expectedMaxConcurrentTotal = anyInt();
+                    List<String> expectedCategories = Collections.emptyList();
+                    boolean expectedThrottleEnabled = anyBoolean();
+                    String expectedThrottleOption = anyString();
+                    boolean expectedLimitOneJobWithMatchingParams = anyBoolean();
+                    String expectedParamsToUseForLimit = anyString();
 
-        ThrottleJobProperty property = new ThrottleJobProperty(expectedMaxConcurrentPerNode,
-                expectedMaxConcurrentTotal,
-                expectedCategories, expectedThrottleEnabled, expectedThrottleOption,
-                expectedLimitOneJobWithMatchingParams, expectedParamsToUseForLimit,
-                ThrottleMatrixProjectOptions.DEFAULT);
+                    ThrottleJobProperty property =
+                            new ThrottleJobProperty(
+                                    expectedMaxConcurrentPerNode,
+                                    expectedMaxConcurrentTotal,
+                                    expectedCategories,
+                                    expectedThrottleEnabled,
+                                    expectedThrottleOption,
+                                    expectedLimitOneJobWithMatchingParams,
+                                    expectedParamsToUseForLimit,
+                                    ThrottleMatrixProjectOptions.DEFAULT);
 
-        assertEquals(expectedMaxConcurrentPerNode, property.getMaxConcurrentPerNode());
-        assertEquals(expectedMaxConcurrentTotal, property.getMaxConcurrentTotal());
-        assertEquals(expectedCategories, property.getCategories());
-        assertEquals(expectedThrottleEnabled, property.getThrottleEnabled());
-        assertEquals(expectedThrottleOption, property.getThrottleOption());
+                    assertEquals(expectedMaxConcurrentPerNode, property.getMaxConcurrentPerNode());
+                    assertEquals(expectedMaxConcurrentTotal, property.getMaxConcurrentTotal());
+                    assertEquals(expectedCategories, property.getCategories());
+                    assertEquals(expectedThrottleEnabled, property.getThrottleEnabled());
+                    assertEquals(expectedThrottleOption, property.getThrottleOption());
+                });
     }
 
     @Test
-    public void testThrottleJob_should_copy_categories_to_concurrency_safe_list() {
-        final String category = anyString();
+    public void testThrottleJobShouldCopyCategoriesToConcurrencySafeList() {
+        story.then(
+                s -> {
+                    final String category = anyString();
 
-        ArrayList<String> unsafeList = new ArrayList<String>() {{
-            add(category);
-        }};
+                    ArrayList<String> unsafeList =
+                            new ArrayList<String>() {
+                                {
+                                    add(category);
+                                }
+                            };
 
-        ThrottleJobProperty property = new ThrottleJobProperty(anyInt(),
-                anyInt(),
-                unsafeList,
-                anyBoolean(),
-                "throttle_option",
-                anyBoolean(),
-                anyString(),
-                ThrottleMatrixProjectOptions.DEFAULT);
+                    ThrottleJobProperty property =
+                            new ThrottleJobProperty(
+                                    anyInt(),
+                                    anyInt(),
+                                    unsafeList,
+                                    anyBoolean(),
+                                    "throttle_option",
+                                    anyBoolean(),
+                                    anyString(),
+                                    ThrottleMatrixProjectOptions.DEFAULT);
 
-        List<String> storedCategories = property.getCategories();
-        assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
-        assertNotSame(
-                "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
-                unsafeList,
-                storedCategories);
-        assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                    List<String> storedCategories = property.getCategories();
+                    assertEquals(
+                            "contents of original and stored list should be the equal",
+                            unsafeList,
+                            storedCategories);
+                    assertNotSame(
+                            "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
+                            unsafeList,
+                            storedCategories);
+                    assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                });
     }
 
     @Test
-    public void testThrottleJob_constructor_handles_null_categories(){
-        ThrottleJobProperty property = new ThrottleJobProperty(anyInt(),
-                anyInt(),
-                null,
-                anyBoolean(),
-                "throttle_option",
-                anyBoolean(),
-                anyString(),
-                ThrottleMatrixProjectOptions.DEFAULT);
+    public void testThrottleJobConstructorHandlesNullCategories() {
+        story.then(
+                s -> {
+                    ThrottleJobProperty property =
+                            new ThrottleJobProperty(
+                                    anyInt(),
+                                    anyInt(),
+                                    null,
+                                    anyBoolean(),
+                                    "throttle_option",
+                                    anyBoolean(),
+                                    anyString(),
+                                    ThrottleMatrixProjectOptions.DEFAULT);
 
-        assertEquals(Collections.<String>emptyList(), property.getCategories());
+                    assertEquals(Collections.<String>emptyList(), property.getCategories());
+                });
     }
 
     @Test
-    public void testDescriptorImpl_should_a_concurrency_safe_list_for_categories(){
-        ThrottleJobProperty.DescriptorImpl descriptor = new ThrottleJobProperty.DescriptorImpl();
+    public void testDescriptorImplShouldAConcurrencySafeListForCategories() {
+        story.then(
+                s -> {
+                    ThrottleJobProperty.DescriptorImpl descriptor =
+                            new ThrottleJobProperty.DescriptorImpl();
 
-        assertTrue(descriptor.getCategories() instanceof CopyOnWriteArrayList);
+                    assertTrue(descriptor.getCategories() instanceof CopyOnWriteArrayList);
 
-        final ThrottleJobProperty.ThrottleCategory category = new ThrottleJobProperty.ThrottleCategory(
-                anyString(), anyInt(), anyInt(), null);
+                    final ThrottleJobProperty.ThrottleCategory category =
+                            new ThrottleJobProperty.ThrottleCategory(
+                                    anyString(), anyInt(), anyInt(), null);
 
-        ArrayList<ThrottleJobProperty.ThrottleCategory> unsafeList =
-                new ArrayList<ThrottleJobProperty.ThrottleCategory>() {{
-                    add(category);
-                }};
+                    ArrayList<ThrottleJobProperty.ThrottleCategory> unsafeList =
+                            new ArrayList<ThrottleJobProperty.ThrottleCategory>() {
+                                {
+                                    add(category);
+                                }
+                            };
 
-
-        descriptor.setCategories(unsafeList);
-        List<ThrottleJobProperty.ThrottleCategory> storedCategories = descriptor.getCategories();
-        assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
-        assertNotSame(
-                "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
-                unsafeList,
-                storedCategories);
-        assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                    descriptor.setCategories(unsafeList);
+                    List<ThrottleJobProperty.ThrottleCategory> storedCategories =
+                            descriptor.getCategories();
+                    assertEquals(
+                            "contents of original and stored list should be the equal",
+                            unsafeList,
+                            storedCategories);
+                    assertNotSame(
+                            "expected unsafe list to be converted to a converted to some other concurrency-safe impl",
+                            unsafeList,
+                            storedCategories);
+                    assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                });
     }
 
 
     private void assertProjects(String category, AbstractProject<?,?>... projects) {
-        r.jenkins.setAuthorizationStrategy(new RejectAllAuthorizationStrategy());
+        story.j.jenkins.setAuthorizationStrategy(new RejectAllAuthorizationStrategy());
         try {
             assertEquals(new HashSet<Queue.Task>(Arrays.asList(projects)), new HashSet<Queue.Task>
                     (ThrottleJobProperty.getCategoryTasks(category)));
         } finally {
-            r.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED); // do not check during e.g. rebuildDependencyGraph from delete
+            story.j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED); // do not check during e.g. rebuildDependencyGraph from delete
         }
     }
     private static class RejectAllAuthorizationStrategy extends AuthorizationStrategy {
@@ -186,4 +327,261 @@ public class ThrottleJobPropertyTest {
         return random.nextInt(10000);
     }
 
+    @Test
+    public void twoTotal() {
+        story.then(
+                s -> {
+                    setupAgentsAndCategories();
+                    WorkflowJob firstJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "first-job");
+                    firstJob.setDefinition(getJobFlow("first", "first-agent"));
+                    firstJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    WorkflowRun firstJobFirstRun = firstJob.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.waitForStart("wait-first-job/1", firstJobFirstRun);
+
+                    WorkflowJob secondJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "second-job");
+                    secondJob.setDefinition(getJobFlow("second", "second-agent"));
+                    secondJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    WorkflowRun secondJobFirstRun = secondJob.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.waitForStart("wait-second-job/1", secondJobFirstRun);
+
+                    WorkflowJob thirdJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "third-job");
+                    thirdJob.setDefinition(getJobFlow("third", "on-agent"));
+                    thirdJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    QueueTaskFuture<WorkflowRun> thirdJobFirstRunFuture =
+                            thirdJob.scheduleBuild2(0);
+                    story.j.jenkins.getQueue().maintain();
+                    assertFalse(story.j.jenkins.getQueue().isEmpty());
+                    Queue.Item queuedItem =
+                            Iterables.getOnlyElement(
+                                    Arrays.asList(story.j.jenkins.getQueue().getItems()));
+                    assertEquals(
+                            Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(2).toString(),
+                            queuedItem.getCauseOfBlockage().getShortDescription());
+                    Node n = story.j.jenkins.getNode("first-agent");
+                    assertNotNull(n);
+                    assertEquals(1, n.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n, firstJobFirstRun);
+
+                    Node n2 = story.j.jenkins.getNode("second-agent");
+                    assertNotNull(n2);
+                    assertEquals(1, n2.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n2, secondJobFirstRun);
+
+                    SemaphoreStep.success("wait-first-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(firstJobFirstRun));
+
+                    WorkflowRun thirdJobFirstRun = thirdJobFirstRunFuture.waitForStart();
+                    SemaphoreStep.waitForStart("wait-third-job/1", thirdJobFirstRun);
+                    assertTrue(story.j.jenkins.getQueue().isEmpty());
+                    assertEquals(1, n.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n, thirdJobFirstRun);
+
+                    SemaphoreStep.success("wait-second-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(secondJobFirstRun));
+
+                    SemaphoreStep.success("wait-third-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(thirdJobFirstRun));
+                });
+    }
+
+    @Ignore
+    @Test
+    public void twoTotalWithRestart() {
+        story.then(
+                s -> {
+                    setupAgentsAndCategories();
+                    WorkflowJob firstJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "first-job");
+                    firstJob.setDefinition(getJobFlow("first", "first-agent"));
+                    firstJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    WorkflowRun firstJobFirstRun = firstJob.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.waitForStart("wait-first-job/1", firstJobFirstRun);
+
+                    WorkflowJob secondJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "second-job");
+                    secondJob.setDefinition(getJobFlow("second", "second-agent"));
+                    secondJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    WorkflowRun secondJobFirstRun = secondJob.scheduleBuild2(0).waitForStart();
+                    SemaphoreStep.waitForStart("wait-second-job/1", secondJobFirstRun);
+
+                    WorkflowJob thirdJob =
+                            story.j.jenkins.createProject(WorkflowJob.class, "third-job");
+                    thirdJob.setDefinition(getJobFlow("third", "on-agent"));
+                    thirdJob.addProperty(
+                            new ThrottleJobProperty(
+                                    null, // maxConcurrentPerNode
+                                    null, // maxConcurrentTotal
+                                    Collections.singletonList(TWO_TOTAL), // categories
+                                    true, // throttleEnabled
+                                    THROTTLE_OPTION_CATEGORY, // throttleOption
+                                    false,
+                                    null,
+                                    ThrottleMatrixProjectOptions.DEFAULT));
+
+                    thirdJob.scheduleBuild2(0);
+                    story.j.jenkins.getQueue().maintain();
+                    assertFalse(story.j.jenkins.getQueue().isEmpty());
+                    Queue.Item queuedItem =
+                            Iterables.getOnlyElement(
+                                    Arrays.asList(story.j.jenkins.getQueue().getItems()));
+                    assertEquals(
+                            Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(2).toString(),
+                            queuedItem.getCauseOfBlockage().getShortDescription());
+                    Node n = story.j.jenkins.getNode("first-agent");
+                    assertNotNull(n);
+                    assertEquals(1, n.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n, firstJobFirstRun);
+
+                    Node n2 = story.j.jenkins.getNode("second-agent");
+                    assertNotNull(n2);
+                    assertEquals(1, n2.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n2, secondJobFirstRun);
+                });
+        story.then(
+                s -> {
+                    RunList<WorkflowRun> firstJobBuilds =
+                            story.j
+                                    .jenkins
+                                    .getItemByFullName("first-job", WorkflowJob.class)
+                                    .getBuilds();
+                    assertEquals(1, firstJobBuilds.size());
+                    WorkflowRun firstJobFirstRun = firstJobBuilds.getLastBuild();
+                    assertNotNull(firstJobFirstRun);
+
+                    RunList<WorkflowRun> secondJobBuilds =
+                            story.j
+                                    .jenkins
+                                    .getItemByFullName("second-job", WorkflowJob.class)
+                                    .getBuilds();
+                    assertEquals(1, secondJobBuilds.size());
+                    WorkflowRun secondJobFirstRun = secondJobBuilds.getLastBuild();
+                    assertNotNull(secondJobFirstRun);
+
+                    story.j.jenkins.getQueue().maintain();
+                    while (!story.j.jenkins.getQueue().getBuildableItems().isEmpty()) {
+                        Thread.sleep(500);
+                        story.j.jenkins.getQueue().maintain();
+                    }
+
+                    assertFalse(story.j.jenkins.getQueue().isEmpty());
+                    Queue.Item queuedItem =
+                            Iterables.getOnlyElement(
+                                    Arrays.asList(story.j.jenkins.getQueue().getItems()));
+                    assertEquals(
+                            Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(2).toString(),
+                            queuedItem.getCauseOfBlockage().getShortDescription());
+
+                    Node n = story.j.jenkins.getNode("first-agent");
+                    assertNotNull(n);
+                    assertEquals(1, n.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n, firstJobFirstRun);
+
+                    Node n2 = story.j.jenkins.getNode("second-agent");
+                    assertNotNull(n2);
+                    assertEquals(1, n2.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n2, secondJobFirstRun);
+
+                    SemaphoreStep.success("wait-first-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(firstJobFirstRun));
+
+                    WorkflowRun thirdJobFirstRun =
+                            (WorkflowRun) queuedItem.getFuture().waitForStart();
+                    SemaphoreStep.waitForStart("wait-third-job/1", thirdJobFirstRun);
+                    assertTrue(story.j.jenkins.getQueue().isEmpty());
+                    assertEquals(1, n.toComputer().countBusy());
+                    hasPlaceholderTaskForRun(n, thirdJobFirstRun);
+
+                    SemaphoreStep.success("wait-second-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(secondJobFirstRun));
+
+                    SemaphoreStep.success("wait-third-job/1", null);
+                    story.j.assertBuildStatusSuccess(story.j.waitForCompletion(thirdJobFirstRun));
+                });
+    }
+
+    private static CpsFlowDefinition getJobFlow(String jobName, String label) {
+        return new CpsFlowDefinition(getThrottleScript(jobName, label), true);
+    }
+
+    private static String getThrottleScript(String jobName, String label) {
+        return "echo 'hi there'\n"
+                + "node('"
+                + label
+                + "') {\n"
+                + "  semaphore 'wait-"
+                + jobName
+                + "-job'\n"
+                + "}\n";
+    }
+
+    private static void hasPlaceholderTaskForRun(Node n, WorkflowRun r) throws Exception {
+        for (Executor exec : n.toComputer().getExecutors()) {
+            if (exec.getCurrentExecutable() != null) {
+                assertTrue(
+                        exec.getCurrentExecutable().getParent()
+                                instanceof ExecutorStepExecution.PlaceholderTask);
+                ExecutorStepExecution.PlaceholderTask task =
+                        (ExecutorStepExecution.PlaceholderTask)
+                                exec.getCurrentExecutable().getParent();
+                while (task.run() == null) {
+                    // Wait for the step context to be ready.
+                    Thread.sleep(500);
+                }
+                assertEquals(r, task.run());
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adds some additional tests in preparation for the merge of jenkinsci/throttle-concurrent-builds-plugin#57:

- We rename `ThrottleIntegrationTest#testThrottlingWithCategory` to `ThrottleIntegrationTest#testThrottlingWithCategoryPerNode` to reflect that it sets `maxConcurrentPerNode`. Then we add a new test: `ThrottleIntegrationTest#testThrottlingWithCategoryTotal`. This is similar to `ThrottleIntegrationTest#testThrottlingWithCategoryPerNode` but sets `maxConcurrentTotal` instead of `maxConcurrentPerNode` for additional code coverage.
- We convert `ThrottleJobPropertyTest` to `RestartableJenkinsRule` and add two new tests: `ThrottleJobPropertyTest#twoTotal` and `ThrottleJobPropertyTest#twoTotalWithRestart`. `ThrottleJobPropertyTest#twoTotal` is similar to`ThrottleStepTest#twoTotal` but uses `ThrottleJobProperty` rather than `ThrottleStep`. `ThrottleJobPropertyTest#twoTotalWithRestart` is similar to `ThrottleJobPropertyTest#twoTotal` but restarts Jenkins to ensure throttling continues working after a Jenkins restart. This test currently fails and is marked with `@Ignore` but will be fixed in jenkinsci/throttle-concurrent-builds-plugin#57.