### PR TITLE
[JENKINS-60481] Add throttleJobProperty @Symbol to ThrottleJobProperty

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -359,7 +360,7 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         return Jenkins.getActiveInstance().getDescriptorByType(DescriptorImpl.class);
     }
     
-    @Extension
+    @Extension @Symbol("throttleJobProperty")
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         private static final Logger LOGGER = Logger.getLogger(DescriptorImpl.class.getName());
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleJobProperty.java
@@ -36,10 +36,10 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
-import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -360,7 +360,8 @@ public class ThrottleJobProperty extends JobProperty<Job<?,?>> {
         return Jenkins.getActiveInstance().getDescriptorByType(DescriptorImpl.class);
     }
     
-    @Extension @Symbol("throttleJobProperty")
+    @Extension
+    @Symbol("throttleJobProperty")
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         private static final Logger LOGGER = Logger.getLogger(DescriptorImpl.class.getName());
 


### PR DESCRIPTION
I pulled inspiration for this change from https://github.com/jenkinsci/branch-api-plugin/pull/127, so I'm hoping it's a fairly straightforward change. In my local testing (using `mvn hpi:run` and then manually installing `Pipeline: Declarative`) I can confirm that before this change, the dropdown suggestions for the Declarative Directive Generator for `options` included only `throttle` and after this change it included both `throttle` and `throttleJobProperty`. When `throttleJobProperty` was selected the UI that came up was as expected for the job property exposed by this plugin.

Also tested by creating a pipeline job and setting this as its pipeline script:
```groovy
pipeline {
    agent any

    options {
        throttleJobProperty(
            categories: [],
            limitOneJobWithMatchingParams: false,
            maxConcurrentPerNode: 0,
            maxConcurrentTotal: 4,
            paramsToUseForLimit: '',
            throttleEnabled: true,
            throttleOption: 'project',
        )
    }

    stages {
        stage('build') {
            agent any
            steps {
                sleep 60
                echo "done"
            }
        }
    }
}
```
Running 5 builds within a minute displayed the expected waiting message, and inspecting the job's configuration showed that it had been persisted as desired there.