### PR TITLE
More test cleanup

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
@@ -44,7 +44,7 @@ public class ThrottleCategoryTest
     public void shouldGetNonEmptyNodeLabeledPairsListThatWasSet()
     {
         String expectedLabel = "aLabel";
-        Integer expectedMax = new Integer(1);
+        Integer expectedMax = 1;
 
         ThrottleJobProperty.ThrottleCategory category =
             new ThrottleJobProperty.ThrottleCategory(testCategoryName, 0, 0, null);

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
@@ -96,7 +96,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
         public JenkinsRule j;
 
         @ScenarioState
-        private List<RunProject> projects = new ArrayList<RunProject>();
+        private List<RunProject> projects = new ArrayList<>();
 
         private int numNodes = 2;
         private int numExecutorsPerNode = 10;
@@ -204,7 +204,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
         }
 
         public WhenAction each_project_is_built_$_times(int i) throws InterruptedException {
-            List<RunProject> projectsToBeBuilt = new ArrayList<RunProject>();
+            List<RunProject> projectsToBeBuilt = new ArrayList<>();
             for (RunProject project : projects) {
                 projectsToBeBuilt.addAll(Collections.nCopies(i, project));
             }
@@ -222,8 +222,8 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
 
         @AfterStage
         private void calculateConcurrentBuilds() throws ExecutionException, InterruptedException {
-            buildingChanges = new TreeMap<Long, Integer>();
-            buildsPerNode = new TreeMap<Long, Map<String, Integer>>();
+            buildingChanges = new TreeMap<>();
+            buildsPerNode = new TreeMap<>();
             for (Future<AbstractBuild<?, ?>> buildFuture : builds) {
                 AbstractBuild<?, ?> build = buildFuture.get();
                 long startTimeInMillis = build.getStartTimeInMillis();
@@ -232,12 +232,12 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
                 buildingChanges.put(endTimeInMillis, Optional.fromNullable(buildingChanges.get(endTimeInMillis)).or(0) - 1);
 
                 String nodeName = build.getBuiltOnStr();
-                Map<String, Integer> nodeChanges = Optional.fromNullable(buildsPerNode.get(startTimeInMillis)).or(new HashMap<String, Integer>());
+                Map<String, Integer> nodeChanges = Optional.fromNullable(buildsPerNode.get(startTimeInMillis)).or(new HashMap<>());
                 nodeChanges.put(nodeName, Optional.fromNullable(nodeChanges.get(nodeName)).or(0) + 1);
                 buildsPerNode.put(startTimeInMillis,
                         nodeChanges);
 
-                nodeChanges = Optional.fromNullable(buildsPerNode.get(endTimeInMillis)).or(new HashMap<String, Integer>());
+                nodeChanges = Optional.fromNullable(buildsPerNode.get(endTimeInMillis)).or(new HashMap<>());
                 nodeChanges.put(nodeName, Optional.fromNullable(nodeChanges.get(nodeName)).or(0) - 1);
                 buildsPerNode.put(endTimeInMillis,
                         nodeChanges);
@@ -269,8 +269,8 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
         }
 
         public ThenSomeOutcome at_most_$_concurrent_builds_per_node(int maxConcurrentPerNode) {
-            Map<String, Integer> numberOfConcurrentBuilds = new HashMap<String, Integer>();
-            Map<String, Integer> maxConcurrentBuilds = new HashMap<String, Integer>();
+            Map<String, Integer> numberOfConcurrentBuilds = new HashMap<>();
+            Map<String, Integer> maxConcurrentBuilds = new HashMap<>();
             for (Map.Entry<Long, Map<String, Integer>> changePerNodePerTime : buildsPerNode.entrySet()) {
                 for (Map.Entry<String, Integer> changesPerNode : changePerNodePerTime.getValue().entrySet()) {
                     String nodeName = changesPerNode.getKey();

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
@@ -2,7 +2,6 @@ package hudson.plugins.throttleconcurrents;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.tngtech.jgiven.Stage;
@@ -27,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -227,18 +227,18 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
             for (Future<AbstractBuild<?, ?>> buildFuture : builds) {
                 AbstractBuild<?, ?> build = buildFuture.get();
                 long startTimeInMillis = build.getStartTimeInMillis();
-                buildingChanges.put(startTimeInMillis, Optional.fromNullable(buildingChanges.get(startTimeInMillis)).or(0) + 1);
+                buildingChanges.put(startTimeInMillis, Optional.ofNullable(buildingChanges.get(startTimeInMillis)).orElse(0) + 1);
                 long endTimeInMillis = startTimeInMillis + build.getDuration();
-                buildingChanges.put(endTimeInMillis, Optional.fromNullable(buildingChanges.get(endTimeInMillis)).or(0) - 1);
+                buildingChanges.put(endTimeInMillis, Optional.ofNullable(buildingChanges.get(endTimeInMillis)).orElse(0) - 1);
 
                 String nodeName = build.getBuiltOnStr();
-                Map<String, Integer> nodeChanges = Optional.fromNullable(buildsPerNode.get(startTimeInMillis)).or(new HashMap<>());
-                nodeChanges.put(nodeName, Optional.fromNullable(nodeChanges.get(nodeName)).or(0) + 1);
+                Map<String, Integer> nodeChanges = Optional.ofNullable(buildsPerNode.get(startTimeInMillis)).orElse(new HashMap<>());
+                nodeChanges.put(nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) + 1);
                 buildsPerNode.put(startTimeInMillis,
                         nodeChanges);
 
-                nodeChanges = Optional.fromNullable(buildsPerNode.get(endTimeInMillis)).or(new HashMap<>());
-                nodeChanges.put(nodeName, Optional.fromNullable(nodeChanges.get(nodeName)).or(0) - 1);
+                nodeChanges = Optional.ofNullable(buildsPerNode.get(endTimeInMillis)).orElse(new HashMap<>());
+                nodeChanges.put(nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) - 1);
                 buildsPerNode.put(endTimeInMillis,
                         nodeChanges);
 
@@ -274,10 +274,10 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
             for (Map.Entry<Long, Map<String, Integer>> changePerNodePerTime : buildsPerNode.entrySet()) {
                 for (Map.Entry<String, Integer> changesPerNode : changePerNodePerTime.getValue().entrySet()) {
                     String nodeName = changesPerNode.getKey();
-                    int newValue = Optional.fromNullable(numberOfConcurrentBuilds.get(nodeName)).or(0) +
+                    int newValue = Optional.ofNullable(numberOfConcurrentBuilds.get(nodeName)).orElse(0) +
                             changesPerNode.getValue();
                     numberOfConcurrentBuilds.put(nodeName, newValue);
-                    if (newValue > Optional.fromNullable(maxConcurrentBuilds.get(nodeName)).or(0)) {
+                    if (newValue > Optional.ofNullable(maxConcurrentBuilds.get(nodeName)).orElse(0)) {
                         maxConcurrentBuilds.put(nodeName, newValue);
                     }
                 }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
@@ -179,7 +179,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
                 Jenkins jenkins = j.getInstance();
                 synchronized (jenkins) {
                     DumbSlave slave = new DumbSlave("slave" + jenkins.getNodes().size(), "dummy",
-                            j.createTmpDir().getPath(), Integer.toString(numExecutorsPerNode), Node.Mode.NORMAL, "", j.createComputerLauncher(null), RetentionStrategy.NOOP, Collections.EMPTY_LIST);
+                            j.createTmpDir().getPath(), Integer.toString(numExecutorsPerNode), Node.Mode.NORMAL, "", j.createComputerLauncher(null), RetentionStrategy.NOOP, Collections.emptyList());
                     jenkins.addNode(slave);
                 }
                 latch.await();

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
@@ -107,12 +107,12 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
             return self();
         }
 
-        public GivenStage maxConcurrentPerNode(int maxConcurrentPerNode) throws IOException {
+        public GivenStage maxConcurrentPerNode(int maxConcurrentPerNode) {
             currentCategory.maxConcurrentPerNode(maxConcurrentPerNode);
             return self();
         }
 
-        public GivenStage maxConcurrentTotal(int maxConcurrentTotal) throws IOException {
+        public GivenStage maxConcurrentTotal(int maxConcurrentTotal) {
             currentCategory.maxConcurrentTotal = maxConcurrentTotal;
             return self();
         }
@@ -125,7 +125,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
             return self();
         }
 
-        public GivenStage $_nodes(int i) throws Exception {
+        public GivenStage $_nodes(int i) {
             numNodes = i;
             return self();
         }
@@ -145,7 +145,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
                 this.j = j;
             }
 
-            public CategorySpec maxConcurrentPerNode(int maxConcurrentPerNode) throws IOException {
+            public CategorySpec maxConcurrentPerNode(int maxConcurrentPerNode) {
                 this.maxConcurrentPerNode = maxConcurrentPerNode;
                 return this;
             }
@@ -322,7 +322,7 @@ public class ThrottleConcurrentTest extends ScenarioTest<ThrottleConcurrentTest.
         }
 
         @Override
-        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
             inBuild.release();
             Thread.sleep(100);
             return true;

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
@@ -128,7 +128,7 @@ public class ThrottleIntegrationTest {
         
         ThrottleJobProperty.DescriptorImpl descriptor
             = (ThrottleJobProperty.DescriptorImpl)r.jenkins.getDescriptor(ThrottleJobProperty.class);
-        descriptor.setCategories(Arrays.asList(
+        descriptor.setCategories(Collections.singletonList(
                 new ThrottleJobProperty.ThrottleCategory(
                         category,
                         1,      // maxConcurrentPerNode
@@ -142,7 +142,7 @@ public class ThrottleIntegrationTest {
         p1.addProperty(new ThrottleJobProperty(
                 null, // maxConcurrentPerNode
                 null, // maxConcurrentTotal
-                Arrays.asList(category),      // categories
+                Collections.singletonList(category),      // categories
                 true,   // throttleEnabled
                 "category",     // throttleOption
                 false,
@@ -156,7 +156,7 @@ public class ThrottleIntegrationTest {
         p2.addProperty(new ThrottleJobProperty(
                 null, // maxConcurrentPerNode
                 null, // maxConcurrentTotal
-                Arrays.asList(category),      // categories
+                Collections.singletonList(category),      // categories
                 true,   // throttleEnabled
                 "category",     // throttleOption
                 false,
@@ -233,7 +233,7 @@ public class ThrottleIntegrationTest {
         
         ThrottleJobProperty.DescriptorImpl descriptor
             = (ThrottleJobProperty.DescriptorImpl)r.jenkins.getDescriptor(ThrottleJobProperty.class);
-        descriptor.setCategories(Arrays.asList(
+        descriptor.setCategories(Collections.singletonList(
                 new ThrottleJobProperty.ThrottleCategory(
                         category,
                         1,      // maxConcurrentPerNode
@@ -248,7 +248,7 @@ public class ThrottleIntegrationTest {
         p1.addProperty(new ThrottleJobProperty(
                 null, // maxConcurrentPerNode
                 null, // maxConcurrentTotal
-                Arrays.asList(category),      // categories
+                Collections.singletonList(category),      // categories
                 true,   // throttleEnabled
                 "category",     // throttleOption
                 false,  // limitOneJobWithMatchingParams
@@ -263,7 +263,7 @@ public class ThrottleIntegrationTest {
         p2.addProperty(new ThrottleJobProperty(
                 null, // maxConcurrentPerNode
                 null, // maxConcurrentTotal
-                Arrays.asList(category),      // categories
+                Collections.singletonList(category),      // categories
                 true,   // throttleEnabled
                 "category",     // throttleOption
                 false,  // limitOneJobWithMatchingParams

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
@@ -73,7 +73,7 @@ public class ThrottleIntegrationTest {
                     labels==null?"":labels,
                     r.createComputerLauncher(env),
                     RetentionStrategy.NOOP,
-                    Collections.<NodeProperty<?>>emptyList()
+                    Collections.emptyList()
             );
             r.jenkins.addNode(slave);
             return slave;
@@ -133,7 +133,7 @@ public class ThrottleIntegrationTest {
                         category,
                         1,      // maxConcurrentPerNode
                         null,   // maxConcurrentTotal
-                        Collections.<NodeLabeledPair>emptyList()
+                        Collections.emptyList()
                 )
         ));
         
@@ -238,7 +238,7 @@ public class ThrottleIntegrationTest {
                         category,
                         1,      // maxConcurrentPerNode
                         null,   // maxConcurrentTotal
-                        Collections.<NodeLabeledPair>emptyList()
+                        Collections.emptyList()
                 )
         ));
         

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleIntegrationTest.java
@@ -37,7 +37,6 @@ import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
-import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -288,7 +288,7 @@ public class ThrottleJobPropertyTest {
 
     @Issue("JENKINS-54578")
     @Test
-    public void clearConfiguredCategories() throws Exception {
+    public void clearConfiguredCategories() {
         story.then(
                 s -> {
                     ThrottleJobProperty.DescriptorImpl descriptor =

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -264,12 +264,7 @@ public class ThrottleJobPropertyTest {
                             new ThrottleJobProperty.ThrottleCategory(
                                     anyString(), anyInt(), anyInt(), null);
 
-                    ArrayList<ThrottleJobProperty.ThrottleCategory> unsafeList =
-                            new ArrayList<ThrottleJobProperty.ThrottleCategory>() {
-                                {
-                                    add(category);
-                                }
-                            };
+                    List<ThrottleJobProperty.ThrottleCategory> unsafeList = Collections.singletonList(category);
 
                     descriptor.setCategories(unsafeList);
                     List<ThrottleJobProperty.ThrottleCategory> storedCategories =

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -328,7 +328,7 @@ public class ThrottleJobPropertyTest {
     private void assertProjects(String category, AbstractProject<?,?>... projects) {
         story.j.jenkins.setAuthorizationStrategy(new RejectAllAuthorizationStrategy());
         try {
-            assertEquals(new HashSet<Queue.Task>(Arrays.asList(projects)), new HashSet<Queue.Task>
+            assertEquals(new HashSet<Queue.Task>(Arrays.asList(projects)), new HashSet<>
                     (ThrottleJobProperty.getCategoryTasks(category)));
         } finally {
             story.j.jenkins.setAuthorizationStrategy(AuthorizationStrategy.UNSECURED); // do not check during e.g. rebuildDependencyGraph from delete

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -226,7 +226,7 @@ public class ThrottleQueueTaskDispatcherTest {
                             List<HtmlInput> inputs;
                             int clickThenWaitForMaxTries = 3;
                             do {
-                                page = (HtmlPage)deeperButton.click();
+                                page = deeperButton.click();
                                 TimeUnit.SECONDS.sleep(1);
                                 form = page.getFormByName(configFormName);
                                 inputs = form.getInputsByName("_.throttledNodeLabel");

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -223,7 +223,7 @@ public class ThrottleQueueTaskDispatcherTest {
                         buttonFound = true;
                         for(int i=0; i<numberOfPairs; i++)
                         {
-                            List<HtmlInput> inputs = null;
+                            List<HtmlInput> inputs;
                             int clickThenWaitForMaxTries = 3;
                             do {
                                 page = (HtmlPage)deeperButton.click();

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -32,7 +32,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlSelect;
 import hudson.model.FreeStyleProject;
 import hudson.plugins.throttleconcurrents.testutils.HtmlUnitHelper;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -194,8 +194,7 @@ public class ThrottleQueueTaskDispatcherTest {
     }
 
     private void configureGlobalThrottling(String labelRoot, int numberOfPairs, int maxConcurrentPerNode)
-    throws InterruptedException, IOException, MalformedURLException
-    {
+    throws InterruptedException, IOException {
         URL url = new URL(r.getURL()+configUrlSuffix);
         HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
@@ -255,8 +254,7 @@ public class ThrottleQueueTaskDispatcherTest {
     }
 
     private void configureJobThrottling(FreeStyleProject project)
-    throws IOException, MalformedURLException
-    {
+    throws IOException {
         URL url = new URL(r.getURL()+project.getUrl()+configUrlSuffix);
         HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
@@ -288,8 +286,7 @@ public class ThrottleQueueTaskDispatcherTest {
     }
 
     private void configureNewNodeWithLabel(String label)
-    throws IOException, MalformedURLException
-    {
+    throws IOException {
         URL url = new URL(r.getURL()+"computer/new");
         HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName("createItem");
@@ -339,8 +336,7 @@ public class ThrottleQueueTaskDispatcherTest {
     }
 
     private String configureLogger()
-    throws IOException, MalformedURLException
-    {
+    throws IOException {
         String logger = ThrottleQueueTaskDispatcher.class.getName();
         r.jenkins.getLog().doNewLogRecorder(logger);
         URL url = new URL(r.getURL()+logUrlPrefix+logger+"/"+configUrlSuffix);
@@ -410,8 +406,7 @@ public class ThrottleQueueTaskDispatcherTest {
     }
 
     private HtmlPage getLoggerPage(String logger)
-    throws IOException, MalformedURLException
-    {
+    throws IOException {
         URL url = new URL(r.getURL()+logUrlPrefix+logger);
         return r.createWebClient().getPage(url);
     }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -393,7 +393,7 @@ public class ThrottleQueueTaskDispatcherTest {
 
     private String expectedTracesMessage(String traceKind, boolean assertingTrue)
     {
-        StringBuffer messagePrefix = new StringBuffer("log shall");
+        StringBuilder messagePrefix = new StringBuilder("log shall");
         if(!assertingTrue) {
             messagePrefix.append(" not");
         }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -21,7 +21,6 @@ import hudson.plugins.throttleconcurrents.pipeline.ThrottleStep;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -333,7 +333,7 @@ public class ThrottleStepTest {
                 freeStyleProject.addProperty(new ThrottleJobProperty(
                         null, // maxConcurrentPerNode
                         null, // maxConcurrentTotal
-                        Arrays.asList(ONE_PER_NODE),      // categories
+                        Collections.singletonList(ONE_PER_NODE),      // categories
                         true,   // throttleEnabled
                         "category",     // throttleOption
                         false,

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -62,11 +62,11 @@ public class ThrottleStepTest {
     public void setupAgentsAndCategories() throws Exception {
         DumbSlave firstAgent = new DumbSlave("first-agent", "dummy agent", firstAgentTmp.getRoot().getAbsolutePath(),
                 "4", Node.Mode.NORMAL, "on-agent", story.j.createComputerLauncher(null),
-                RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
+                RetentionStrategy.NOOP, Collections.emptyList());
 
         DumbSlave secondAgent = new DumbSlave("second-agent", "dummy agent", secondAgentTmp.getRoot().getAbsolutePath(),
                 "4", Node.Mode.NORMAL, "on-agent", story.j.createComputerLauncher(null),
-                RetentionStrategy.NOOP, Collections.<NodeProperty<?>>emptyList());
+                RetentionStrategy.NOOP, Collections.emptyList());
 
         story.j.jenkins.addNode(firstAgent);
         story.j.jenkins.addNode(secondAgent);

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -343,7 +343,7 @@ public class ThrottleStepTest {
                 freeStyleProject.setAssignedLabel(Label.get("first-agent"));
                 freeStyleProject.getBuildersList().add(new TestBuilder() {
                     @Override
-                    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+                    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException {
                         semaphore.acquire();
                         return true;
                     }
@@ -437,7 +437,7 @@ public class ThrottleStepTest {
         });
     }
 
-    private void hasPlaceholderTaskForRun(Node n, WorkflowRun r) throws Exception {
+    private void hasPlaceholderTaskForRun(Node n, WorkflowRun r) {
         for (Executor exec : n.toComputer().getExecutors()) {
             if (exec.getCurrentExecutable() != null) {
                 assertTrue(exec.getCurrentExecutable().getParent() instanceof ExecutorStepExecution.PlaceholderTask);


### PR DESCRIPTION
More cleanup of tests, this time fixing IntelliJ IDE warnings. I intentionally did not fix warnings in non-test code to minimize risk. The remaining non-test warnings can be fixed at a later time when this plugin is in a better-maintained state.