### PR TITLE
Remove usage of deprecated buildPlugin.recommendedConfigurations()

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,15 @@
 #!/usr/bin/env groovy
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin(useAci: true, configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(useAci: true, configurations: [
+  // Test the long-term support end of the compatibility spectrum (i.e., the minimum required
+  // Jenkins version).
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+
+  // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
+  [ platform: 'linux', jdk: '8', jenkins: '2.222.3', javaLevel: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: '2.222.3', javaLevel: '8' ],
+
+  // Test the bleeding edge of the compatibility spectrum (i.e., the latest supported Java runtime).
+  [ platform: 'linux', jdk: '11', jenkins: '2.222.3', javaLevel: '8' ],
+])


### PR DESCRIPTION
There has recently been some instability around `buildPlugin.recommendedConfigurations()` and even some talk of deprecating it entirely, so let's stop relying on it and define our own testing matrix. I've provided comments explaining the matrix I've chosen.