### PR TITLE
ThrottleJobProperty/global.jelly: replace "table" by "div"

### DIFF
--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/global.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/global.jelly
@@ -4,7 +4,7 @@
   <f:section title="Throttle Concurrent Builds">
     <f:entry title="Multi-Project Throttle Categories" field="categories">
       <f:repeatable field="categories" add="${%Add Category}" minimum="0">
-        <table width="100%">
+        <div width="100%">
           <f:entry title="Category Name" field="categoryName">
             <f:textbox />
           </f:entry>
@@ -14,16 +14,16 @@
           <f:entry title="${%Maximum Concurrent Builds Per Node}" field="maxConcurrentPerNode">
             <f:textbox />
           </f:entry>
-        </table>
+        </div>
         <f:repeatable field="nodeLabeledPairs" add="${%Add Maximum Per Labeled Node}" minimum="0" header="${%Maximum Per Labeled Node}">
-          <table width="100%">
+          <div width="100%">
             <f:entry title="${%Throttled Node Label}" field="throttledNodeLabel">
               <f:textbox />
             </f:entry>
             <f:entry title="${%Maximum Concurrent Builds Per Node Labeled As Above}" field="maxConcurrentPerNodeLabeled">
               <f:textbox />
             </f:entry>
-          </table>
+          </div>
           <div align="right">
             <f:repeatableDeleteButton/>
           </div>


### PR DESCRIPTION
Supposedly this factors into the table-to-div migration effort.

CC @timja 