### PR TITLE
Add test for JENKINS-46858 Comma separated parameters doesn't limit jobs

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -27,6 +27,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -145,6 +146,207 @@ public class ThrottleJobPropertyTest {
         assertEquals(expectedCategories, property.getCategories());
         assertEquals(expectedThrottleEnabled, property.getThrottleEnabled());
         assertEquals(expectedThrottleOption, property.getThrottleOption());
+    }
+
+    @Ignore("JENKINS-46858")
+    @Test
+    @WithoutJenkins
+    public void testThrottleJobConstructorShouldParseParamsToUseForLimit() {
+        Integer expectedMaxConcurrentPerNode = anyInt();
+        Integer expectedMaxConcurrentTotal = anyInt();
+        List<String> expectedCategories = Collections.emptyList();
+        boolean expectedThrottleEnabled = anyBoolean();
+        String expectedThrottleOption = anyString();
+        boolean expectedLimitOneJobWithMatchingParams = true;
+
+        // Mix the comma and whitespace separators as commas were documented in the original
+        // codebase but did not work so people must have used whitespace de-facto.
+
+        // Note that the data type of paramsToUseForLimit is a List (ordered) so in the test we
+        // expect it as such. Production code seems to use it as an unordered set as suffices for
+        // filtering, however.
+
+        // (0*) Null and empty string inputs should result in an empty list object; surrounding
+        // whitespace should be truncated so a non-empty input made of just separators is
+        // effectively empty for us too.
+        String assignedParamsToUseForLimit00 = null;
+        List<String> expectedParamsToUseForLimit00 = new ArrayList<>();
+        ThrottleJobProperty property00 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit00,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit00, property00.getParamsToCompare());
+
+        String assignedParamsToUseForLimit0 = "";
+        List<String> expectedParamsToUseForLimit0 = new ArrayList<>();
+        ThrottleJobProperty property0 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit0,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit0, property0.getParamsToCompare());
+
+        String assignedParamsToUseForLimit0a = " ";
+        List<String> expectedParamsToUseForLimit0a = new ArrayList<>();
+        ThrottleJobProperty property0a =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit0a,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit0a, property0a.getParamsToCompare());
+
+        String assignedParamsToUseForLimit0b = " , ";
+        List<String> expectedParamsToUseForLimit0b = new ArrayList<>();
+        ThrottleJobProperty property0b =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit0b,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit0b, property0b.getParamsToCompare());
+
+        String assignedParamsToUseForLimit0c = " ,,,  \n";
+        List<String> expectedParamsToUseForLimit0c = new ArrayList<>();
+        ThrottleJobProperty property0c =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit0c,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit0c, property0c.getParamsToCompare());
+
+        // (1) One buildarg name listed in the input becomes the only one string in the list;
+        // surrounding whitespace should be truncated.
+        String assignedParamsToUseForLimit1 = "ONE_PARAM";
+        List<String> expectedParamsToUseForLimit1 = Collections.singletonList("ONE_PARAM");
+        ThrottleJobProperty property1 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit1,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit1, property1.getParamsToCompare());
+
+        String assignedParamsToUseForLimit1a = " ONE_PARAM";
+        List<String> expectedParamsToUseForLimit1a = Collections.singletonList("ONE_PARAM");
+        ThrottleJobProperty property1a =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit1a,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit1a, property1a.getParamsToCompare());
+
+        String assignedParamsToUseForLimit1b = " ONE_PARAM\n";
+        List<String> expectedParamsToUseForLimit1b = Collections.singletonList("ONE_PARAM");
+        ThrottleJobProperty property1b =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit1b,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit1b, property1b.getParamsToCompare());
+
+        // (2) Two buildarg names listed in the input become two strings in the list.
+        String assignedParamsToUseForLimit2 = "TWO,PARAMS";
+        List<String> expectedParamsToUseForLimit2 = Arrays.asList("TWO", "PARAMS");
+        ThrottleJobProperty property2 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit2,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit2, property2.getParamsToCompare());
+
+        // (3) Different separators are handled the same.
+        String assignedParamsToUseForLimit3 = "THREE DIFFERENT,PARAMS";
+        List<String> expectedParamsToUseForLimit3 = Arrays.asList("THREE", "DIFFERENT", "PARAMS");
+        ThrottleJobProperty property3 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit3,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit3, property3.getParamsToCompare());
+
+        // (4) Several separating tokens together must go away as one: we want no empties in the
+        // resulting list.
+        String assignedParamsToUseForLimit4 = "FOUR ,SOMEWHAT\t,DIFFERENT , PARAMS";
+        List<String> expectedParamsToUseForLimit4 =
+                Arrays.asList("FOUR", "SOMEWHAT", "DIFFERENT", "PARAMS");
+        ThrottleJobProperty property4 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit4,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit4, property4.getParamsToCompare());
+
+        // (5) Java does not really have multilines, but still... note that if any whitespace should
+        // be there in the carry-over of string representation, it is the coder's responsibility to
+        // ensure some.
+        String assignedParamsToUseForLimit5 = "Multi\nline" + "string,for	kicks\n" + "EOL";
+        List<String> expectedParamsToUseForLimit5 =
+                Arrays.asList("Multi", "linestring", "for", "kicks", "EOL");
+        ThrottleJobProperty property5 =
+                new ThrottleJobProperty(
+                        expectedMaxConcurrentPerNode,
+                        expectedMaxConcurrentTotal,
+                        expectedCategories,
+                        expectedThrottleEnabled,
+                        expectedThrottleOption,
+                        expectedLimitOneJobWithMatchingParams,
+                        assignedParamsToUseForLimit5,
+                        ThrottleMatrixProjectOptions.DEFAULT);
+        assertEquals(expectedParamsToUseForLimit5, property5.getParamsToCompare());
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-46858](https://issues.jenkins.io/browse/JENKINS-46858). Cleaned up version of the test from #77 by @jimklimov.