### PR TITLE
[JENKINS-37809] Throttling based on parameters does not work with Pipeline jobs

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -315,7 +315,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     private boolean isAnotherBuildWithSameParametersRunningOnNode(Node node, Queue.Item item) {
         ThrottleJobProperty tjp = getThrottleJobProperty(item.task);
         if (tjp == null) {
-            // If the property has been ocasionally deleted by this call,
+            // If the property has been occasionally deleted by this call,
             // it does not make sense to limit the throttling by parameter.
             return false;
         }
@@ -389,11 +389,22 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     public List<ParameterValue> getParametersFromWorkUnit(WorkUnit unit) {
         List<ParameterValue> paramsList = new ArrayList<>();
 
-        if (unit != null && unit.context != null && unit.context.actions != null) {
-            List<Action> actions = unit.context.actions;
-            for (Action action : actions) {
-                if (action instanceof ParametersAction) {
-                    paramsList = ((ParametersAction)action).getParameters();
+        if (unit != null && unit.context != null) {
+            if (unit.context.actions != null && !unit.context.actions.isEmpty()) {
+                List<Action> actions = unit.context.actions;
+                for (Action action : actions) {
+                    if (action instanceof ParametersAction) {
+                        paramsList = ((ParametersAction) action).getParameters();
+                    }
+                }
+            } else if (unit.context.task instanceof PlaceholderTask) {
+                PlaceholderTask placeholderTask = (PlaceholderTask) unit.context.task;
+                Run<?, ?> run = placeholderTask.run();
+                if (run != null) {
+                    List<ParametersAction> actions = run.getActions(ParametersAction.class);
+                    for (ParametersAction action : actions) {
+                        paramsList = action.getParameters();
+                    }
                 }
             }
         }

--- a/src/test/java/hudson/plugins/throttleconcurrents/TestUtil.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/TestUtil.java
@@ -30,6 +30,7 @@ public class TestUtil {
 
     // TODO move this into ThrottleJobProperty and use consistently; same for "project".
     static final String THROTTLE_OPTION_CATEGORY = "category";
+    static final String THROTTLE_OPTION_PROJECT = "project";
 
     static final ThrottleJobProperty.ThrottleCategory ONE_PER_NODE =
             new ThrottleJobProperty.ThrottleCategory("one_per_node", 1, 0, null);


### PR DESCRIPTION
Adds test coverage for this functionality for both classic job types and Pipeline jobs. The test for classic job types passed without the changes to `src/main`, but the test for Pipeline jobs failed without the changes to `src/main` due to [JENKINS-37809](https://issues.jenkins.io/browse/JENKINS-37809). With the changes to `src/main`, the test for Pipeline jobs now passes.