### PR TITLE
fixes checkboxes layout for categories selection on job options

### DIFF
--- a/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/throttleconcurrents/ThrottleJobProperty/config.jelly
@@ -35,8 +35,8 @@
     <j:if test="${!empty(descriptor.categories)}">
       <f:entry title="${%Multi-Project Throttle Category}">
         <j:forEach var="cat" items="${descriptor.categories}">
-          <f:checkbox name="categories" json="${cat.categoryName}" checked="${instance.categories.contains(cat.categoryName)}" />
-          <label class="attach-previous">${cat.categoryName}</label>
+          <f:checkbox name="categories" json="${cat.categoryName}" title="${cat.categoryName}"
+                      checked="${instance.categories.contains(cat.categoryName)}" />
           <st:nbsp/>
         </j:forEach>
       </f:entry>


### PR DESCRIPTION
Fixes checkboxes layout for categories selection on job options.

On current versions of jenkins, the first category checkbox is being rendered to the left of the section title causing confusion to the user.

I was able to fix it changing the separate label element to title attribute in checkbox.
I am not a frontend developer, so I don't know if this is the better solution. Please review.

Jira ticket: https://issues.jenkins.io/browse/JENKINS-65745

Tested on:
- jenkins: 2.277.4 (official docker image jenkins/jenkins:lts@sha256:3a441b1bcd2ce630b7bad3486e7972a8d107f25098a4a7c28b7f1a96d61742a6)

- throttle-concurrents: 2.2 

Current plugin version:
![4724335fe3d44dceb902a3374128f7e1](https://user-images.githubusercontent.com/1053559/120907728-43090700-c63a-11eb-8ea9-f7ec06ef48e8.png)

after selecting cat1 and cat3

![e5a77373627a4fa4a01425ade25c848f](https://user-images.githubusercontent.com/1053559/120907733-48665180-c63a-11eb-9c9a-c0dc97c29fb2.png)


After patch:
![2b3bbdd144054a0b918650f86d727b78](https://user-images.githubusercontent.com/1053559/120907741-51efb980-c63a-11eb-9a01-7c082fff4a6f.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
