### PR TITLE
[Docs] Add an example to configure the plugin via JCasC

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,6 +51,20 @@ image:doc/images/global_categoryConfig.png[Global Category Configuration]
 
 To set an unlimited value of concurrent builds for a restriction, use 0.
 
+Also global configuration could be configured via https://plugins.jenkins.io/configuration-as-code/[Jenkins Configuration as Code] (JCasC) as following:
+[source,yaml]
+----
+unclassified:
+  throttleJobProperty:
+    categories:
+    - categoryName: "myThrottleCategory"
+      maxConcurrentTotal: 5
+      maxConcurrentPerNode: 2
+      nodeLabeledPairs:
+      - throttledNodeLabel: "docker"
+        maxConcurrentPerNodeLabeled: 1
+----
+
 === Throttling of classic job types
 
 Classic job types (e.g., Freestyle, Matrix, and Job DSL) can be configured via job properties in the job configuration screen.


### PR DESCRIPTION
Infrastructure as Code is essential nowadays and using [Jenkins Configuration as Code](https://plugins.jenkins.io/configuration-as-code/) (aka JCasC) is common in the Kubernetes ecosystem.

This PR to add to the docs an example about how to configure the plugin via JCasC.The Throttle Concurrent Builds plugin is supported out of the box in JCasC ... so this PR just updates the docs.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
