### PR TITLE
Try re-enabling memory-intensive tests on Windows

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyFreestyleTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyFreestyleTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertTrue;
 import com.cloudbees.hudson.plugins.folder.Folder;
 import com.google.common.collect.Iterables;
 
-import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -48,7 +47,6 @@ import hudson.model.queue.QueueTaskFuture;
 import hudson.security.GlobalMatrixAuthorizationStrategy;
 
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -95,10 +93,6 @@ public class ThrottleJobPropertyFreestyleTest {
 
     @Test
     public void testNoThrottling() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
 
         FreeStyleProject p1 = j.createFreeStyleProject();
@@ -130,10 +124,6 @@ public class ThrottleJobPropertyFreestyleTest {
 
     @Test
     public void onePerNode() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 
@@ -195,10 +185,6 @@ public class ThrottleJobPropertyFreestyleTest {
 
     @Test
     public void twoTotal() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.TWO_TOTAL);
@@ -285,10 +271,6 @@ public class ThrottleJobPropertyFreestyleTest {
 
     @Test
     public void limitOneJobWithMatchingParams() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
 
         FreeStyleProject project = j.createFreeStyleProject();
@@ -344,10 +326,6 @@ public class ThrottleJobPropertyFreestyleTest {
     @Issue("JENKINS-25326")
     @Test
     public void testThrottlingWithCategoryInFolder() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Iterables;
 
-import hudson.Functions;
 import hudson.model.Node;
 import hudson.model.Queue;
 import hudson.util.RunList;
@@ -17,7 +16,6 @@ import hudson.util.RunList;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,10 +40,6 @@ public class ThrottleJobPropertyPipelineRestartTest {
 
     @Test
     public void twoTotalWithRestart() throws Throwable {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         String[] jobNames = new String[2];
         String[] agentNames = new String[2];
         sessions.then(

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Iterables;
 
-import hudson.Functions;
 import hudson.model.Node;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
@@ -20,7 +19,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -57,10 +55,6 @@ public class ThrottleJobPropertyPipelineTest {
     @Ignore("TODO Doesn't work at present")
     @Test
     public void onePerNode() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 
@@ -119,10 +113,6 @@ public class ThrottleJobPropertyPipelineTest {
 
     @Test
     public void twoTotal() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.TWO_TOTAL);
@@ -207,10 +197,6 @@ public class ThrottleJobPropertyPipelineTest {
     @Issue("JENKINS-37809")
     @Test
     public void limitOneJobWithMatchingParams() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
 
         WorkflowJob project = j.createProject(WorkflowJob.class);

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleStepTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Iterables;
 
-import hudson.Functions;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -31,7 +30,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,10 +68,6 @@ public class ThrottleStepTest {
 
     @Test
     public void onePerNode() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 
@@ -114,10 +108,6 @@ public class ThrottleStepTest {
 
     @Test
     public void duplicateCategories() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
@@ -161,10 +151,6 @@ public class ThrottleStepTest {
 
     @Test
     public void multipleCategories() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE, TestUtil.OTHER_ONE_PER_NODE);
@@ -224,10 +210,6 @@ public class ThrottleStepTest {
 
     @Test
     public void onePerNodeParallel() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
@@ -319,10 +301,6 @@ public class ThrottleStepTest {
 
     @Test
     public void twoTotal() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.TWO_TOTAL);
@@ -375,10 +353,6 @@ public class ThrottleStepTest {
 
     @Test
     public void interopWithFreestyle() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         final Semaphore semaphore = new Semaphore(1);
 
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
@@ -517,10 +491,6 @@ public class ThrottleStepTest {
     @Issue("JENKINS-49006")
     @Test
     public void throttledPipelinesByCategoryCopyOnWrite() throws Exception {
-        Assume.assumeFalse(
-                "TODO Windows ACI agents do not have enough memory to run this test",
-                Functions.isWindows());
-
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 


### PR DESCRIPTION
These tests were disabled a while ago on Windows due to the Windows ACI agents not having enough memory. Perhaps they'll work now?