### PR TITLE
Add documentation and tests for throttle step in options block

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -179,6 +179,29 @@ pipeline {
 }
 ----
 
+=== Example 4: Throttling of declarative stages
+
+It is possible to throttle a stage of a declarative pipeline if the stage assigns an agent. The throttle step should be placed in the options block of the stage.
+
+[source,groovy]
+----
+pipeline {
+    agent none
+
+    stages {
+        stage('sleep') {
+            agent any
+            options {
+                throttle(['test_4'])
+            }
+            steps {
+                sh "sleep 500"
+                echo "Done"
+            }
+        }
+    }
+}
+
 == Unsupported use cases
 
 This section contains links to the use cases which are *not* supported.

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@ THE SOFTWARE.
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkinsci.plugins</groupId>
+            <artifactId>pipeline-model-definition</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.tngtech.jgiven</groupId>
             <artifactId>jgiven-junit</artifactId>
             <version>1.2.2</version>


### PR DESCRIPTION
It is possible to use the throttle step in the options block of a
stage to throttle single stages in a declarative pipeline. This
commit documents this behaviour and adds a test for it.