### PR TITLE
[JENKINS-67978] Fix for job parameters on built-in node

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -340,7 +340,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         // whether one of these executing units is an instance
         // of the queued item we were asked to compare to.
         if (computer != null) {
-            for (Executor exec : computer.getExecutors()) {
+            for (Executor exec : computer.getAllExecutors()) {
                 // TODO: refactor into a nameEquals helper method
                 final Queue.Executable currentExecutable = exec.getCurrentExecutable();
                 final SubTask parentTask = currentExecutable != null ? currentExecutable.getParent() : null;


### PR DESCRIPTION
This PR fixes problem when option "Prevent multiple jobs with identical parameters from running concurrently" is not working (at least one issue is open: [JENKINS-67978](https://issues.jenkins.io/browse/JENKINS-67978)), and I've seen some similar question on the Internet.

### Testing done

I tested this change manually in my environment. Before applying this patch, parameters were ignored, same job with equal parameters was triggered, didn't wait for the previous job with the same parameter to finish.
After applying the patch, job with the same paparameters is waiting for an existing job with the same parameters to finish - exactly as it shoud..

I am not a programmer, so I'm not able to implement automated tests. I was able to add some debugging and to guess what may fix the problem, but this is already too good for me :-)

Note there are few other places where getExecutors() is used in this plugin, may be someone need to consider change that paces too, or may be not, I'm not sure. I suggest to approve this PR first because it fixes the problem that really needed by some users, and then decide if other places needs to be changed similarly.

P.S. There is some kind of explanation on my findings in my first [comment](https://issues.jenkins.io/browse/JENKINS-67978?focusedCommentId=438752&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-438752) to [JENKINS-67978](https://issues.jenkins.io/browse/JENKINS-67978)

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

Closes #269