### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,23 +125,6 @@ THE SOFTWARE.
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-support</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.tngtech.jgiven</groupId>
-      <artifactId>jgiven-junit</artifactId>
-      <version>2.0.2</version>
-      <scope>test</scope>
-      <exclusions>
-        <!-- Provided by Jenkins core -->
-        <exclusion>
-          <groupId>org.fusesource.jansi</groupId>
-          <artifactId>jansi</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <!-- Dependencies for test -->
     <dependency>

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleCategoryTest.java
@@ -16,11 +16,11 @@
  */
 package hudson.plugins.throttleconcurrents;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class initiates the testing of {@link hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory}.<br>
@@ -28,20 +28,18 @@ import org.junit.Test;
  * -Test methods for {@link hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory#getNodeLabeledPairs()}.
  * @author marco.miller@ericsson.com
  */
-public class ThrottleCategoryTest {
+class ThrottleCategoryTest {
     private static final String testCategoryName = "aCategory";
 
     @Test
-    public void shouldGetEmptyNodeLabeledPairsListUponInitialNull() {
+    void shouldGetEmptyNodeLabeledPairsListUponInitialNull() {
         ThrottleJobProperty.ThrottleCategory category =
                 new ThrottleJobProperty.ThrottleCategory(testCategoryName, 0, 0, null);
-        assertTrue(
-                "nodeLabeledPairs shall be empty",
-                category.getNodeLabeledPairs().isEmpty());
+        assertTrue(category.getNodeLabeledPairs().isEmpty(), "nodeLabeledPairs shall be empty");
     }
 
     @Test
-    public void shouldGetNonEmptyNodeLabeledPairsListThatWasSet() {
+    void shouldGetNonEmptyNodeLabeledPairsListThatWasSet() {
         String expectedLabel = "aLabel";
         Integer expectedMax = 1;
 
@@ -54,12 +52,12 @@ public class ThrottleCategoryTest {
         Integer actualMax = category.getNodeLabeledPairs().get(0).getMaxConcurrentPerNodeLabeled();
 
         assertEquals(
-                "throttledNodeLabel " + actualLabel + " does not match expected " + expectedLabel,
                 expectedLabel,
-                actualLabel);
+                actualLabel,
+                "throttledNodeLabel " + actualLabel + " does not match expected " + expectedLabel);
         assertEquals(
-                "maxConcurrentPerNodeLabeled " + actualMax + " does not match expected " + expectedMax,
                 expectedMax,
-                actualMax);
+                actualMax,
+                "maxConcurrentPerNodeLabeled " + actualMax + " does not match expected " + expectedMax);
     }
 }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleConcurrentTest.java
@@ -2,14 +2,9 @@ package hudson.plugins.throttleconcurrents;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.tngtech.jgiven.Stage;
-import com.tngtech.jgiven.annotation.AfterStage;
-import com.tngtech.jgiven.annotation.BeforeStage;
-import com.tngtech.jgiven.annotation.ScenarioState;
-import com.tngtech.jgiven.junit.ScenarioTest;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
@@ -21,301 +16,198 @@ import hudson.slaves.ComputerListener;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.RetentionStrategy;
 import hudson.tasks.Builder;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import jenkins.model.Jenkins;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-@Ignore("Depends on a newer version of Guava than can be used with Pipeline")
-public class ThrottleConcurrentTest
-        extends ScenarioTest<
-                ThrottleConcurrentTest.GivenStage,
-                ThrottleConcurrentTest.WhenAction,
-                ThrottleConcurrentTest.ThenSomeOutcome> {
-    @Rule
-    @ScenarioState
-    public JenkinsRule j = new JenkinsRule();
+@WithJenkins
+class ThrottleConcurrentTest {
+
+    private static final String CATEGORY = "cat";
 
     @Test
-    public void category_per_node_throttling() throws Exception {
-        int nodeNumber = 2;
-        int maxPerNode = 3;
+    void category_per_node_throttling(JenkinsRule j) throws Exception {
+        // given
+        int numNodes = 2;
+        int numExecutorsPerNode = 10;
 
-        given().$_nodes(nodeNumber)
-                .with()
-                .$_executors(10)
-                .and()
-                .a_category()
-                .with()
-                .maxConcurrentPerNode(maxPerNode)
-                .and()
-                .$_projects_having_this_category(maxPerNode * nodeNumber + 5);
+        int maxConcurrentPerNode = 3;
+        int maxConcurrentTotal = 0;
 
-        when().each_project_is_built_$_times(3);
+        setCategories(maxConcurrentPerNode, maxConcurrentTotal);
+        initExecutors(j, numExecutorsPerNode, numNodes);
+        List<RunProject> projects = initProjects(j, maxConcurrentPerNode * numNodes + 5);
 
-        then().there_should_be_at_most_$_concurrent_builds(nodeNumber * maxPerNode)
-                .and()
-                .at_most_$_concurrent_builds_per_node(maxPerNode);
-    }
+        // when
+        List<Future<AbstractBuild<?, ?>>> builds = executeBuilds(projects);
 
-    @Test
-    public void category_total_throttling() throws Exception {
-        int nodeNumber = 2;
-        int maxTotal = 4;
+        TreeMap<Long, Integer> buildingChanges = new TreeMap<>();
+        TreeMap<Long, Map<String, Integer>> buildsPerNode = new TreeMap<>();
+        getBuildResults(builds, buildingChanges, buildsPerNode);
 
-        given().$_nodes(nodeNumber)
-                .with()
-                .$_executors(10)
-                .and()
-                .a_category()
-                .with()
-                .maxConcurrentTotal(maxTotal)
-                .and()
-                .$_projects_having_this_category(maxTotal + 3);
+        // then
+        assertNumberOfBuilds(buildingChanges, numNodes * maxConcurrentPerNode);
 
-        when().each_project_is_built_$_times(3);
-
-        then().there_should_be_at_most_$_concurrent_builds(maxTotal);
-    }
-
-    public static class GivenStage extends Stage<GivenStage> {
-        @ScenarioState
-        private CategorySpec currentCategory;
-
-        @ScenarioState
-        public JenkinsRule j;
-
-        @ScenarioState
-        private List<RunProject> projects = new ArrayList<>();
-
-        private int numNodes = 2;
-        private int numExecutorsPerNode = 10;
-
-        public GivenStage a_category() {
-            currentCategory = new CategorySpec(j);
-            return self();
-        }
-
-        public GivenStage maxConcurrentPerNode(int maxConcurrentPerNode) {
-            currentCategory.maxConcurrentPerNode(maxConcurrentPerNode);
-            return self();
-        }
-
-        public GivenStage maxConcurrentTotal(int maxConcurrentTotal) {
-            currentCategory.maxConcurrentTotal = maxConcurrentTotal;
-            return self();
-        }
-
-        public GivenStage $_projects_having_this_category(int num) throws Exception {
-            configureNodes();
-            for (int i = 0; i < num; i++) {
-                projects.add(new RunProject(j, currentCategory.name));
-            }
-            return self();
-        }
-
-        public GivenStage $_nodes(int i) {
-            numNodes = i;
-            return self();
-        }
-
-        public GivenStage $_executors(int i) {
-            numExecutorsPerNode = i;
-            return self();
-        }
-
-        public static class CategorySpec extends Stage<CategorySpec> {
-            public String name = "cat";
-            public int maxConcurrentPerNode;
-            public int maxConcurrentTotal;
-            private JenkinsRule j;
-
-            public CategorySpec(JenkinsRule j) {
-                this.j = j;
-            }
-
-            public CategorySpec maxConcurrentPerNode(int maxConcurrentPerNode) {
-                this.maxConcurrentPerNode = maxConcurrentPerNode;
-                return this;
-            }
-
-            private void createCategory() {
-                ThrottleJobProperty.DescriptorImpl descriptor = ThrottleJobProperty.fetchDescriptor();
-                assertNotNull(descriptor);
-                descriptor.setCategories(Collections.singletonList(new ThrottleJobProperty.ThrottleCategory(
-                        name, maxConcurrentPerNode, maxConcurrentTotal, null)));
-            }
-        }
-
-        @AfterStage
-        private void createCategory() {
-            if (currentCategory != null) {
-                currentCategory.createCategory();
-            }
-        }
-
-        private void configureNodes() throws Exception {
-            j.getInstance().setNumExecutors(numExecutorsPerNode);
-
-            for (int k = 0; k < numNodes - 1; k++) {
-                final CountDownLatch latch = new CountDownLatch(1);
-                ComputerListener waiter = new ComputerListener() {
-                    @Override
-                    public void onOnline(Computer C, TaskListener t) {
-                        latch.countDown();
-                        unregister();
-                    }
-                };
-                waiter.register();
-                Jenkins jenkins = j.getInstance();
-                synchronized (jenkins) {
-                    DumbSlave slave = new DumbSlave(
-                            "slave" + jenkins.getNodes().size(),
-                            "dummy",
-                            j.createTmpDir().getPath(),
-                            Integer.toString(numExecutorsPerNode),
-                            Node.Mode.NORMAL,
-                            "",
-                            j.createComputerLauncher(null),
-                            RetentionStrategy.NOOP,
-                            Collections.emptyList());
-                    jenkins.addNode(slave);
+        Map<String, Integer> concurrentBuilds = new HashMap<>();
+        Map<String, Integer> maxConcurrentBuilds = new HashMap<>();
+        for (Map.Entry<Long, Map<String, Integer>> changePerNodePerTime : buildsPerNode.entrySet()) {
+            for (Map.Entry<String, Integer> changesPerNode :
+                    changePerNodePerTime.getValue().entrySet()) {
+                String nodeName = changesPerNode.getKey();
+                int newValue =
+                        Optional.ofNullable(concurrentBuilds.get(nodeName)).orElse(0) + changesPerNode.getValue();
+                concurrentBuilds.put(nodeName, newValue);
+                if (newValue
+                        > Optional.ofNullable(maxConcurrentBuilds.get(nodeName)).orElse(0)) {
+                    maxConcurrentBuilds.put(nodeName, newValue);
                 }
-                latch.await();
             }
+        }
+        assertThat(new HashSet<>(maxConcurrentBuilds.values()), contains(maxConcurrentPerNode));
+    }
+
+    @Test
+    void category_total_throttling(JenkinsRule j) throws Exception {
+        // given
+        int numNodes = 2;
+        int numExecutorsPerNode = 10;
+
+        int maxConcurrentPerNode = 0;
+        int maxConcurrentTotal = 4;
+
+        setCategories(maxConcurrentPerNode, maxConcurrentTotal);
+        initExecutors(j, numExecutorsPerNode, numNodes);
+        List<RunProject> projects = initProjects(j, maxConcurrentTotal + 3);
+
+        // when
+        List<Future<AbstractBuild<?, ?>>> builds = executeBuilds(projects);
+
+        TreeMap<Long, Integer> buildingChanges = new TreeMap<>();
+        TreeMap<Long, Map<String, Integer>> buildsPerNode = new TreeMap<>();
+        getBuildResults(builds, buildingChanges, buildsPerNode);
+
+        // then
+        assertNumberOfBuilds(buildingChanges, maxConcurrentTotal);
+    }
+
+    private static void assertNumberOfBuilds(TreeMap<Long, Integer> buildingChanges, int maxConcurrentTotal) {
+        int numberOfConcurrentBuilds = 0;
+        int maxConcurrentBuilds = 0;
+        for (Map.Entry<Long, Integer> startEndTime : buildingChanges.entrySet()) {
+            numberOfConcurrentBuilds += startEndTime.getValue();
+            if (numberOfConcurrentBuilds > maxConcurrentBuilds) {
+                maxConcurrentBuilds = numberOfConcurrentBuilds;
+            }
+        }
+        assertEquals(maxConcurrentTotal, maxConcurrentBuilds);
+    }
+
+    private static void getBuildResults(
+            List<Future<AbstractBuild<?, ?>>> builds,
+            TreeMap<Long, Integer> buildingChanges,
+            TreeMap<Long, Map<String, Integer>> buildsPerNode)
+            throws Exception {
+        for (Future<AbstractBuild<?, ?>> buildFuture : builds) {
+            AbstractBuild<?, ?> build = buildFuture.get();
+            long startTimeInMillis = build.getStartTimeInMillis();
+            buildingChanges.put(
+                    startTimeInMillis,
+                    Optional.ofNullable(buildingChanges.get(startTimeInMillis)).orElse(0) + 1);
+            long endTimeInMillis = startTimeInMillis + build.getDuration();
+            buildingChanges.put(
+                    endTimeInMillis,
+                    Optional.ofNullable(buildingChanges.get(endTimeInMillis)).orElse(0) - 1);
+
+            String nodeName = build.getBuiltOnStr();
+            Map<String, Integer> nodeChanges =
+                    Optional.ofNullable(buildsPerNode.get(startTimeInMillis)).orElse(new HashMap<>());
+            nodeChanges.put(
+                    nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) + 1);
+            buildsPerNode.put(startTimeInMillis, nodeChanges);
+
+            nodeChanges =
+                    Optional.ofNullable(buildsPerNode.get(endTimeInMillis)).orElse(new HashMap<>());
+            nodeChanges.put(
+                    nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) - 1);
+            buildsPerNode.put(endTimeInMillis, nodeChanges);
         }
     }
 
-    public static class WhenAction extends Stage<WhenAction> {
-        @ScenarioState
-        private List<RunProject> projects;
+    private static List<Future<AbstractBuild<?, ?>>> executeBuilds(List<RunProject> projects) throws Exception {
+        ExecutorService executorService = Executors.newFixedThreadPool(projects.size() * 2);
 
-        ExecutorService executorService;
-        private List<Future<AbstractBuild<?, ?>>> builds;
-
-        @ScenarioState
-        private TreeMap<Long, Integer> buildingChanges;
-
-        @ScenarioState
-        private TreeMap<Long, Map<String, Integer>> buildsPerNode;
-
-        @BeforeStage
-        private void init() {
-            executorService = Executors.newFixedThreadPool(projects.size() * 2);
-        }
-
-        public WhenAction each_project_is_built_$_times(int i) throws InterruptedException {
+        try {
             List<RunProject> projectsToBeBuilt = new ArrayList<>();
             for (RunProject project : projects) {
-                projectsToBeBuilt.addAll(Collections.nCopies(i, project));
+                projectsToBeBuilt.addAll(Collections.nCopies(3, project));
             }
             Collections.shuffle(projectsToBeBuilt);
 
-            builds = executorService.invokeAll(projectsToBeBuilt);
-
-            return self();
-        }
-
-        @AfterStage
-        private void teardown() {
+            return executorService.invokeAll(projectsToBeBuilt);
+        } finally {
             executorService.shutdown();
-        }
-
-        @AfterStage
-        private void calculateConcurrentBuilds() throws ExecutionException, InterruptedException {
-            buildingChanges = new TreeMap<>();
-            buildsPerNode = new TreeMap<>();
-            for (Future<AbstractBuild<?, ?>> buildFuture : builds) {
-                AbstractBuild<?, ?> build = buildFuture.get();
-                long startTimeInMillis = build.getStartTimeInMillis();
-                buildingChanges.put(
-                        startTimeInMillis,
-                        Optional.ofNullable(buildingChanges.get(startTimeInMillis))
-                                        .orElse(0)
-                                + 1);
-                long endTimeInMillis = startTimeInMillis + build.getDuration();
-                buildingChanges.put(
-                        endTimeInMillis,
-                        Optional.ofNullable(buildingChanges.get(endTimeInMillis))
-                                        .orElse(0)
-                                - 1);
-
-                String nodeName = build.getBuiltOnStr();
-                Map<String, Integer> nodeChanges = Optional.ofNullable(buildsPerNode.get(startTimeInMillis))
-                        .orElse(new HashMap<>());
-                nodeChanges.put(
-                        nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) + 1);
-                buildsPerNode.put(startTimeInMillis, nodeChanges);
-
-                nodeChanges =
-                        Optional.ofNullable(buildsPerNode.get(endTimeInMillis)).orElse(new HashMap<>());
-                nodeChanges.put(
-                        nodeName, Optional.ofNullable(nodeChanges.get(nodeName)).orElse(0) - 1);
-                buildsPerNode.put(endTimeInMillis, nodeChanges);
-            }
         }
     }
 
-    public static class ThenSomeOutcome extends Stage<ThenSomeOutcome> {
-        @ScenarioState
-        private TreeMap<Long, Integer> buildingChanges;
+    private static void initExecutors(JenkinsRule j, int numExecutorsPerNode, int numNodes) throws Exception {
+        j.getInstance().setNumExecutors(numExecutorsPerNode);
 
-        @ScenarioState
-        private TreeMap<Long, Map<String, Integer>> buildsPerNode;
-
-        @ScenarioState
-        private JenkinsRule j;
-
-        public ThenSomeOutcome there_should_be_at_most_$_concurrent_builds(int i) {
-            int numberOfConcurrentBuilds = 0;
-            int maxConcurrentBuilds = 0;
-            for (Map.Entry<Long, Integer> startEndTime : buildingChanges.entrySet()) {
-                numberOfConcurrentBuilds += startEndTime.getValue();
-                if (numberOfConcurrentBuilds > maxConcurrentBuilds) {
-                    maxConcurrentBuilds = numberOfConcurrentBuilds;
+        for (int k = 0; k < numNodes - 1; k++) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            ComputerListener waiter = new ComputerListener() {
+                @Override
+                public void onOnline(Computer c, TaskListener t) {
+                    latch.countDown();
+                    unregister();
                 }
+            };
+            waiter.register();
+            Jenkins jenkins = j.getInstance();
+            synchronized (jenkins) {
+                DumbSlave slave = new DumbSlave(
+                        "slave" + jenkins.getNodes().size(),
+                        "dummy",
+                        j.createTmpDir().getPath(),
+                        Integer.toString(numExecutorsPerNode),
+                        Node.Mode.NORMAL,
+                        "",
+                        j.createComputerLauncher(null),
+                        RetentionStrategy.NOOP,
+                        Collections.emptyList());
+                jenkins.addNode(slave);
             }
-            assertEquals(i, maxConcurrentBuilds);
-            return self();
+            latch.await();
         }
+    }
 
-        public ThenSomeOutcome at_most_$_concurrent_builds_per_node(int maxConcurrentPerNode) {
-            Map<String, Integer> numberOfConcurrentBuilds = new HashMap<>();
-            Map<String, Integer> maxConcurrentBuilds = new HashMap<>();
-            for (Map.Entry<Long, Map<String, Integer>> changePerNodePerTime : buildsPerNode.entrySet()) {
-                for (Map.Entry<String, Integer> changesPerNode :
-                        changePerNodePerTime.getValue().entrySet()) {
-                    String nodeName = changesPerNode.getKey();
-                    int newValue = Optional.ofNullable(numberOfConcurrentBuilds.get(nodeName))
-                                    .orElse(0)
-                            + changesPerNode.getValue();
-                    numberOfConcurrentBuilds.put(nodeName, newValue);
-                    if (newValue
-                            > Optional.ofNullable(maxConcurrentBuilds.get(nodeName))
-                                    .orElse(0)) {
-                        maxConcurrentBuilds.put(nodeName, newValue);
-                    }
-                }
-            }
-            assertThat(new ArrayList<>(maxConcurrentBuilds.values()), contains(maxConcurrentPerNode));
-            return self();
+    private static void setCategories(int maxConcurrentPerNode, int maxConcurrentTotal) {
+        ThrottleJobProperty.DescriptorImpl descriptor = ThrottleJobProperty.fetchDescriptor();
+        assertNotNull(descriptor);
+        descriptor.setCategories(Collections.singletonList(
+                new ThrottleJobProperty.ThrottleCategory(CATEGORY, maxConcurrentPerNode, maxConcurrentTotal, null)));
+    }
+
+    private static List<RunProject> initProjects(JenkinsRule j, int count) throws Exception {
+        List<RunProject> projects = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            projects.add(new RunProject(j, CATEGORY));
         }
+        return projects;
     }
 
     private static class RunProject implements Callable<AbstractBuild<?, ?>> {
@@ -323,13 +215,13 @@ public class ThrottleConcurrentTest
         private final FreeStyleProject project;
         private final JenkinsRule j;
 
-        private RunProject(JenkinsRule j, String categoryName) throws IOException {
+        private RunProject(JenkinsRule j, String categoryName) throws Exception {
             this.j = j;
             project = createProjectInCategory(categoryName);
             project.getBuildersList().add(new SemaphoreBuilder(inQueue));
         }
 
-        private FreeStyleProject createProjectInCategory(String categoryName) throws IOException {
+        private FreeStyleProject createProjectInCategory(String categoryName) throws Exception {
             FreeStyleProject freeStyleProject = j.createFreeStyleProject();
             freeStyleProject.addProperty(new ThrottleJobProperty(
                     0,
@@ -351,7 +243,7 @@ public class ThrottleConcurrentTest
     }
 
     private static class SemaphoreBuilder extends Builder {
-        private Semaphore inBuild;
+        private final transient Semaphore inBuild;
 
         SemaphoreBuilder(Semaphore inBuild) {
             this.inBuild = inBuild;

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
@@ -46,8 +46,8 @@ public class ThrottleJobPropertyPipelineRestartTest {
         String[] agentNames = new String[2];
         sessions.then(j -> {
             List<Node> agents = new ArrayList<>();
-            Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
-            Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
+            Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp.getRoot(), agents, null, 4, "on-agent");
+            Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp.getRoot(), agents, null, 4, "on-agent");
             agentNames[0] = firstAgent.getNodeName();
             agentNames[1] = secondAgent.getNodeName();
             TestUtil.setupCategories(TestUtil.TWO_TOTAL);

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -2,61 +2,62 @@ package hudson.plugins.throttleconcurrents;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.Node;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import hudson.model.StringParameterDefinition;
 import hudson.model.queue.QueueTaskFuture;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.jvnet.hudson.test.BuildWatcher;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
-public class ThrottleJobPropertyPipelineTest {
+@WithJenkins
+class ThrottleJobPropertyPipelineTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
 
-    @ClassRule
-    public static BuildWatcher buildWatcher = new BuildWatcher();
+    @TempDir
+    private File firstAgentTmp;
 
-    @Rule
-    public TemporaryFolder firstAgentTmp = new TemporaryFolder();
-
-    @Rule
-    public TemporaryFolder secondAgentTmp = new TemporaryFolder();
+    @TempDir
+    private File secondAgentTmp;
 
     private List<Node> agents = new ArrayList<>();
 
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+    }
+
     /** Clean up agents. */
-    @After
-    public void tearDown() throws Exception {
+    @AfterEach
+    void tearDown() throws Exception {
         TestUtil.tearDown(j, agents);
         agents = new ArrayList<>();
     }
 
-    @Ignore("TODO Doesn't work at present")
+    @Disabled("TODO Doesn't work at present")
     @Test
-    public void onePerNode() throws Exception {
+    void onePerNode() throws Exception {
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 
@@ -93,7 +94,7 @@ public class ThrottleJobPropertyPipelineTest {
         assertFalse(j.jenkins.getQueue().isEmpty());
 
         List<Queue.Item> queuedItemList =
-                Arrays.stream(j.jenkins.getQueue().getItems()).collect(Collectors.toList());
+                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
         assertEquals(1, queuedItemList.size());
         Queue.Item queuedItem = queuedItemList.get(0);
         Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
@@ -116,7 +117,7 @@ public class ThrottleJobPropertyPipelineTest {
     }
 
     @Test
-    public void twoTotal() throws Exception {
+    void twoTotal() throws Exception {
         Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
         Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
         TestUtil.setupCategories(TestUtil.TWO_TOTAL);
@@ -167,7 +168,7 @@ public class ThrottleJobPropertyPipelineTest {
         j.jenkins.getQueue().maintain();
         assertFalse(j.jenkins.getQueue().isEmpty());
         List<Queue.Item> queuedItemList =
-                Arrays.stream(j.jenkins.getQueue().getItems()).collect(Collectors.toList());
+                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
         assertEquals(1, queuedItemList.size());
         Queue.Item queuedItem = queuedItemList.get(0);
         Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
@@ -202,7 +203,7 @@ public class ThrottleJobPropertyPipelineTest {
 
     @Issue("JENKINS-37809")
     @Test
-    public void limitOneJobWithMatchingParams() throws Exception {
+    void limitOneJobWithMatchingParams() throws Exception {
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, null);
 
         WorkflowJob project = j.createProject(WorkflowJob.class);
@@ -228,7 +229,7 @@ public class ThrottleJobPropertyPipelineTest {
         j.jenkins.getQueue().maintain();
         assertFalse(j.jenkins.getQueue().isEmpty());
         List<Queue.Item> queuedItemList =
-                Arrays.stream(j.jenkins.getQueue().getItems()).collect(Collectors.toList());
+                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
         assertEquals(1, queuedItemList.size());
         Queue.Item queuedItem = queuedItemList.get(0);
         Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyTest.java
@@ -1,12 +1,14 @@
 package hudson.plugins.throttleconcurrents;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.AbstractProject;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
@@ -27,23 +29,21 @@ import org.htmlunit.WebClientUtil;
 import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlForm;
 import org.htmlunit.html.HtmlPage;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import org.jvnet.hudson.test.recipes.LocalData;
 
-public class ThrottleJobPropertyTest {
+@WithJenkins
+class ThrottleJobPropertyTest {
 
-    private final Random random = new Random(System.currentTimeMillis());
-
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private static final Random random = new Random(System.currentTimeMillis());
 
     @Issue("JENKINS-19623")
     @Test
-    public void testGetCategoryProjects() throws Exception {
+    void testGetCategoryProjects(JenkinsRule j) throws Exception {
         String alpha = "alpha", beta = "beta", gamma = "gamma"; // category names
         FreeStyleProject p1 = j.createFreeStyleProject("p1");
         FreeStyleProject p2 = j.createFreeStyleProject("p2");
@@ -78,23 +78,23 @@ public class ThrottleJobPropertyTest {
                 ThrottleMatrixProjectOptions.DEFAULT));
         // TODO when core dep ≥1.480.3, add cloudbees-folder as a test dependency so we can check
         // jobs inside folders
-        assertProjects(alpha, p3);
-        assertProjects(beta, p3, p4);
-        assertProjects(gamma, p4);
-        assertProjects("delta");
+        assertProjects(j, alpha, p3);
+        assertProjects(j, beta, p3, p4);
+        assertProjects(j, gamma, p4);
+        assertProjects(j, "delta");
         p4.renameTo("p-4");
-        assertProjects(gamma, p4);
+        assertProjects(j, gamma, p4);
         p4.delete();
-        assertProjects(gamma);
+        assertProjects(j, gamma);
         AbstractProject<?, ?> p3b = j.jenkins.<AbstractProject<?, ?>>copy(p3, "p3b");
-        assertProjects(beta, p3, p3b);
+        assertProjects(j, beta, p3, p3b);
         p3.removeProperty(ThrottleJobProperty.class);
-        assertProjects(beta, p3b);
+        assertProjects(j, beta, p3b);
     }
 
     @Test
     @WithoutJenkins
-    public void testToStringWithNulls() {
+    void testToStringWithNulls() {
         ThrottleJobProperty tjp =
                 new ThrottleJobProperty(0, 0, null, false, null, false, "", ThrottleMatrixProjectOptions.DEFAULT);
         assertNotNull(tjp.toString());
@@ -102,7 +102,7 @@ public class ThrottleJobPropertyTest {
 
     @Test
     @WithoutJenkins
-    public void testThrottleJobConstructorShouldStoreArguments() {
+    void testThrottleJobConstructorShouldStoreArguments() {
         Integer expectedMaxConcurrentPerNode = anyInt();
         Integer expectedMaxConcurrentTotal = anyInt();
         List<String> expectedCategories = Collections.emptyList();
@@ -131,7 +131,7 @@ public class ThrottleJobPropertyTest {
     @Issue("JENKINS-46858")
     @Test
     @WithoutJenkins
-    public void testThrottleJobConstructorShouldParseParamsToUseForLimit() {
+    void testThrottleJobConstructorShouldParseParamsToUseForLimit() {
         Integer expectedMaxConcurrentPerNode = anyInt();
         Integer expectedMaxConcurrentTotal = anyInt();
         List<String> expectedCategories = Collections.emptyList();
@@ -301,7 +301,11 @@ public class ThrottleJobPropertyTest {
         // (5) Java does not really have multilines, but still... note that if any whitespace should
         // be there in the carry-over of string representation, it is the coder's responsibility to
         // ensure some.
-        String assignedParamsToUseForLimit5 = "Multi\nline" + "string,for	kicks\n" + "EOL";
+        String assignedParamsToUseForLimit5 =
+                """
+                Multi
+                linestring,for	kicks
+                EOL""";
         List<String> expectedParamsToUseForLimit5 = Arrays.asList("Multi", "linestring", "for", "kicks", "EOL");
         ThrottleJobProperty property5 = new ThrottleJobProperty(
                 expectedMaxConcurrentPerNode,
@@ -317,7 +321,7 @@ public class ThrottleJobPropertyTest {
 
     @Test
     @WithoutJenkins
-    public void testThrottleJobShouldCopyCategoriesToConcurrencySafeList() {
+    void testThrottleJobShouldCopyCategoriesToConcurrencySafeList() {
         final String category = anyString();
 
         List<String> unsafeList = new ArrayList<>();
@@ -334,17 +338,17 @@ public class ThrottleJobPropertyTest {
                 ThrottleMatrixProjectOptions.DEFAULT);
 
         List<String> storedCategories = property.getCategories();
-        assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
+        assertEquals(unsafeList, storedCategories, "contents of original and stored list should be the equal");
         assertNotSame(
-                "expected unsafe list to be converted to a converted to some other" + " concurrency-safe impl",
                 unsafeList,
-                storedCategories);
-        assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                storedCategories,
+                "expected unsafe list to be converted to a converted to some other" + " concurrency-safe impl");
+        assertInstanceOf(CopyOnWriteArrayList.class, storedCategories);
     }
 
     @Test
     @WithoutJenkins
-    public void testThrottleJobConstructorHandlesNullCategories() {
+    void testThrottleJobConstructorHandlesNullCategories() {
         ThrottleJobProperty property = new ThrottleJobProperty(
                 anyInt(),
                 anyInt(),
@@ -359,11 +363,11 @@ public class ThrottleJobPropertyTest {
     }
 
     @Test
-    public void testDescriptorImplShouldAConcurrencySafeListForCategories() {
+    void testDescriptorImplShouldAConcurrencySafeListForCategories(JenkinsRule j) {
         ThrottleJobProperty.DescriptorImpl descriptor = ThrottleJobProperty.fetchDescriptor();
         assertNotNull(descriptor);
 
-        assertTrue(descriptor.getCategories() instanceof CopyOnWriteArrayList);
+        assertInstanceOf(CopyOnWriteArrayList.class, descriptor.getCategories());
 
         final ThrottleJobProperty.ThrottleCategory category =
                 new ThrottleJobProperty.ThrottleCategory(anyString(), anyInt(), anyInt(), null);
@@ -372,12 +376,12 @@ public class ThrottleJobPropertyTest {
 
         descriptor.setCategories(unsafeList);
         List<ThrottleJobProperty.ThrottleCategory> storedCategories = descriptor.getCategories();
-        assertEquals("contents of original and stored list should be the equal", unsafeList, storedCategories);
+        assertEquals(unsafeList, storedCategories, "contents of original and stored list should be the equal");
         assertNotSame(
-                "expected unsafe list to be converted to a converted to some other" + " concurrency-safe impl",
                 unsafeList,
-                storedCategories);
-        assertTrue(storedCategories instanceof CopyOnWriteArrayList);
+                storedCategories,
+                "expected unsafe list to be converted to a converted to some other" + " concurrency-safe impl");
+        assertInstanceOf(CopyOnWriteArrayList.class, storedCategories);
     }
 
     /**
@@ -387,19 +391,19 @@ public class ThrottleJobPropertyTest {
     @Issue("JENKINS-49006")
     @LocalData
     @Test
-    public void throttledPipelinesByCategoryMigratesOldData() {
+    void throttledPipelinesByCategoryMigratesOldData(JenkinsRule j) {
         ThrottleJobProperty.DescriptorImpl descriptor = ThrottleJobProperty.fetchDescriptor();
         assertNotNull(descriptor);
 
         Map<String, List<String>> throttledPipelinesByCategory =
                 descriptor.getThrottledPipelinesForCategory(TestUtil.TWO_TOTAL.getCategoryName());
-        assertTrue(throttledPipelinesByCategory instanceof CopyOnWriteMap.Tree);
+        assertInstanceOf(CopyOnWriteMap.Tree.class, throttledPipelinesByCategory);
         assertEquals(3, throttledPipelinesByCategory.size());
         assertEquals(
                 new HashSet<>(Arrays.asList("first-job#1", "second-job#1", "third-job#1")),
                 throttledPipelinesByCategory.keySet());
         for (List<String> flowNodes : throttledPipelinesByCategory.values()) {
-            assertTrue(flowNodes instanceof CopyOnWriteArrayList);
+            assertInstanceOf(CopyOnWriteArrayList.class, flowNodes);
             assertEquals(1, flowNodes.size());
             assertEquals("3", flowNodes.get(0));
         }
@@ -407,7 +411,7 @@ public class ThrottleJobPropertyTest {
 
     @Issue("JENKINS-54578")
     @Test
-    public void clearConfiguredCategories() throws Exception {
+    void clearConfiguredCategories(JenkinsRule j) throws Exception {
         ThrottleJobProperty.DescriptorImpl descriptor = ThrottleJobProperty.fetchDescriptor();
         assertNotNull(descriptor);
 
@@ -437,7 +441,7 @@ public class ThrottleJobPropertyTest {
         assertTrue(descriptor.getCategories().isEmpty());
     }
 
-    private void assertProjects(String category, AbstractProject<?, ?>... projects) {
+    private static void assertProjects(JenkinsRule j, String category, AbstractProject<?, ?>... projects) {
         j.jenkins.setAuthorizationStrategy(new RejectAllAuthorizationStrategy());
         try {
             assertEquals(
@@ -452,32 +456,35 @@ public class ThrottleJobPropertyTest {
     private static class RejectAllAuthorizationStrategy extends AuthorizationStrategy {
         RejectAllAuthorizationStrategy() {}
 
+        @NonNull
         @Override
         public ACL getRootACL() {
             return new AuthorizationStrategy.Unsecured().getRootACL();
         }
 
+        @NonNull
         @Override
         public Collection<String> getGroups() {
             return Collections.emptySet();
         }
 
+        @NonNull
         @Override
-        public ACL getACL(Job<?, ?> project) {
+        public ACL getACL(@NonNull Job<?, ?> project) {
             fail("not even supposed to be looking at " + project);
             return super.getACL(project);
         }
     }
 
-    private String anyString() {
+    private static String anyString() {
         return "concurrency_" + anyInt();
     }
 
-    private boolean anyBoolean() {
+    private static boolean anyBoolean() {
         return random.nextBoolean();
     }
 
-    private int anyInt() {
+    private static int anyInt() {
         return random.nextInt(10000);
     }
 }

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -16,10 +16,10 @@
  */
 package hudson.plugins.throttleconcurrents;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import hudson.model.FreeStyleProject;
 import hudson.plugins.throttleconcurrents.testutils.HtmlUnitHelper;
@@ -39,9 +39,9 @@ import org.htmlunit.html.HtmlOption;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlRadioButtonInput;
 import org.htmlunit.html.HtmlSelect;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * This class initiates the testing of {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher}.<br>
@@ -49,7 +49,8 @@ import org.jvnet.hudson.test.JenkinsRule;
  * -Happens to test {@link hudson.plugins.throttleconcurrents.ThrottleQueueTaskDispatcher#getMaxConcurrentPerNodeBasedOnMatchingLabels(hudson.model.Node, hudson.plugins.throttleconcurrents.ThrottleJobProperty.ThrottleCategory, int)}.
  * @author marco.miller@ericsson.com
  */
-public class ThrottleQueueTaskDispatcherTest {
+@WithJenkins
+class ThrottleQueueTaskDispatcherTest {
     private static final String buttonsXPath = "//button";
     private static final String configFormName = "config";
     private static final String configUrlSuffix = "configure";
@@ -76,19 +77,16 @@ public class ThrottleQueueTaskDispatcherTest {
     private static final int someCategoryWideMaxConcurrentPerNode = 1;
     private static final int greaterCategoryWideMaxConcurrentPerNode = configureOneMaxLabelPair + 1;
 
-    @Rule
-    public JenkinsRule r = new JenkinsRule();
-
     /**
      * @throws ExecutionException upon Jenkins project build scheduling issue.
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
     @Test
-    public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPair()
+    void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPair(JenkinsRule r)
             throws ExecutionException, InterruptedException, IOException {
         assertBasedOnMaxLabelPairMatchingOrNot(
-                configureOneMaxLabelPair, noCategoryWideMaxConcurrentPerNode, expectMatch, configureNodeLabel);
+                r, configureOneMaxLabelPair, noCategoryWideMaxConcurrentPerNode, expectMatch, configureNodeLabel);
     }
 
     /**
@@ -97,10 +95,10 @@ public class ThrottleQueueTaskDispatcherTest {
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
     @Test
-    public void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPairs()
+    void testShouldConsiderTaskAsBlockableStillUponMatchingMaxLabelPairs(JenkinsRule r)
             throws ExecutionException, InterruptedException, IOException {
         assertBasedOnMaxLabelPairMatchingOrNot(
-                configureTwoMaxLabelPairs, noCategoryWideMaxConcurrentPerNode, expectMatch, configureNodeLabel);
+                r, configureTwoMaxLabelPairs, noCategoryWideMaxConcurrentPerNode, expectMatch, configureNodeLabel);
     }
 
     /**
@@ -109,9 +107,10 @@ public class ThrottleQueueTaskDispatcherTest {
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
     @Test
-    public void testShouldConsiderTaskAsBlockableStillUponMatchingLabelPairWithLowestMax()
+    void testShouldConsiderTaskAsBlockableStillUponMatchingLabelPairWithLowestMax(JenkinsRule r)
             throws ExecutionException, InterruptedException, IOException {
         assertBasedOnMaxLabelPairMatchingOrNot(
+                r,
                 configureOneMaxLabelPair, // => label-pair max of 1, still to match as *the* max;
                 greaterCategoryWideMaxConcurrentPerNode, // greater than label-pair max but still
                 expectMatch,
@@ -124,10 +123,10 @@ public class ThrottleQueueTaskDispatcherTest {
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
     @Test
-    public void testShouldConsiderTaskAsBuildableStillUponMismatchingMaxLabelPairs()
+    void testShouldConsiderTaskAsBuildableStillUponMismatchingMaxLabelPairs(JenkinsRule r)
             throws ExecutionException, InterruptedException, IOException {
         assertBasedOnMaxLabelPairMatchingOrNot(
-                configureTwoMaxLabelPairs, someCategoryWideMaxConcurrentPerNode, expectMismatch, configureNodeLabel);
+                r, configureTwoMaxLabelPairs, someCategoryWideMaxConcurrentPerNode, expectMismatch, configureNodeLabel);
     }
 
     /**
@@ -136,10 +135,14 @@ public class ThrottleQueueTaskDispatcherTest {
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
     @Test
-    public void testShouldConsiderTaskAsBuildableStillUponNoNodeLabel()
+    void testShouldConsiderTaskAsBuildableStillUponNoNodeLabel(JenkinsRule r)
             throws ExecutionException, InterruptedException, IOException {
         assertBasedOnMaxLabelPairMatchingOrNot(
-                configureOneMaxLabelPair, someCategoryWideMaxConcurrentPerNode, expectMismatch, configureNoNodeLabel);
+                r,
+                configureOneMaxLabelPair,
+                someCategoryWideMaxConcurrentPerNode,
+                expectMismatch,
+                configureNoNodeLabel);
     }
 
     /**
@@ -151,35 +154,36 @@ public class ThrottleQueueTaskDispatcherTest {
      * @throws InterruptedException upon Jenkins global configuration issue.
      * @throws IOException upon many potential Jenkins IO issues during test.
      */
-    private void assertBasedOnMaxLabelPairMatchingOrNot(
-            int targetedPairNumber, int maxConcurrentPerNode, boolean expectMatch, boolean configureNodeLabel)
+    private static void assertBasedOnMaxLabelPairMatchingOrNot(
+            JenkinsRule r,
+            int targetedPairNumber,
+            int maxConcurrentPerNode,
+            boolean expectMatch,
+            boolean configureNodeLabel)
             throws ExecutionException, InterruptedException, IOException {
         if (configureNodeLabel) {
             String nodeLabelSuffix = expectMatch ? "" : "other";
-            configureNewNodeWithLabel(testCategoryLabel + targetedPairNumber + nodeLabelSuffix);
+            configureNewNodeWithLabel(r, testCategoryLabel + targetedPairNumber + nodeLabelSuffix);
         }
-        configureGlobalThrottling(testCategoryLabel, targetedPairNumber, maxConcurrentPerNode);
+        configureGlobalThrottling(r, testCategoryLabel, targetedPairNumber, maxConcurrentPerNode);
 
         FreeStyleProject project = r.createFreeStyleProject();
-        configureJobThrottling(project);
-        String logger = configureLogger();
+        configureJobThrottling(r, project);
+        String logger = configureLogger(r);
         project.scheduleBuild2(0).get();
-        HtmlPage page = getLoggerPage(logger);
+        HtmlPage page = getLoggerPage(r, logger);
         if (expectMatch) {
+            assertTrue(page.asNormalizedText().contains(matchTrace), expectedTracesMessage(match, true));
             assertTrue(
-                    expectedTracesMessage(match, true), page.asNormalizedText().contains(matchTrace));
-            assertTrue(
-                    expectedTracesMessage(max, true), page.asNormalizedText().contains(maxTrace + targetedPairNumber));
+                    page.asNormalizedText().contains(maxTrace + targetedPairNumber), expectedTracesMessage(max, true));
         } else {
-            assertTrue(
-                    expectedTracesMessage(mismatch, true),
-                    page.asNormalizedText().contains(mismatchTrace));
-            assertFalse(
-                    expectedTracesMessage(max, false), page.asNormalizedText().contains(maxTrace));
+            assertTrue(page.asNormalizedText().contains(mismatchTrace), expectedTracesMessage(mismatch, true));
+            assertFalse(page.asNormalizedText().contains(maxTrace), expectedTracesMessage(max, false));
         }
     }
 
-    private void configureGlobalThrottling(String labelRoot, int numberOfPairs, int maxConcurrentPerNode)
+    private static void configureGlobalThrottling(
+            JenkinsRule r, String labelRoot, int numberOfPairs, int maxConcurrentPerNode)
             throws InterruptedException, IOException {
         URL url = new URL(r.getURL() + configUrlSuffix);
         HtmlPage page = r.createWebClient().getPage(url);
@@ -217,8 +221,8 @@ public class ThrottleQueueTaskDispatcherTest {
                             } while (inputs.isEmpty() && clickThenWaitForMaxTries > 0);
 
                             assertFalse(
-                                    buttonText + " button clicked; no resulting field found on " + url,
-                                    inputs.isEmpty());
+                                    inputs.isEmpty(),
+                                    buttonText + " button clicked; no resulting field found on " + url);
                             inputs.get(i).setValue(labelRoot + (i + 1));
 
                             inputs = form.getInputsByName("_.maxConcurrentPerNodeLabeled");
@@ -238,7 +242,7 @@ public class ThrottleQueueTaskDispatcherTest {
         failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
     }
 
-    private void configureJobThrottling(FreeStyleProject project) throws IOException {
+    private static void configureJobThrottling(JenkinsRule r, FreeStyleProject project) throws IOException {
         URL url = new URL(r.getURL() + project.getUrl() + configUrlSuffix);
         HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName(configFormName);
@@ -252,7 +256,7 @@ public class ThrottleQueueTaskDispatcherTest {
                 String checkboxName = "throttleEnabled";
                 HtmlElement checkbox = page.getElementByName(checkboxName);
                 assertNotNull(
-                        checkboxName + " checkbox not found on test job config page; plugin installed?", checkbox);
+                        checkbox, checkboxName + " checkbox not found on test job config page; plugin installed?");
                 checkbox.click();
 
                 List<HtmlRadioButtonInput> radios = form.getRadioButtonsByName("throttleOption");
@@ -269,7 +273,7 @@ public class ThrottleQueueTaskDispatcherTest {
         failWithMessageIfButtonNotFoundOnPage(buttonFound, buttonText, url);
     }
 
-    private void configureNewNodeWithLabel(String label) throws IOException {
+    private static void configureNewNodeWithLabel(JenkinsRule r, String label) throws IOException {
         URL url = new URL(r.getURL() + "computer/new");
         HtmlPage page = r.createWebClient().getPage(url);
         HtmlForm form = page.getFormByName("createItem");
@@ -306,7 +310,7 @@ public class ThrottleQueueTaskDispatcherTest {
         failWithMessageIfButtonNotFoundOnPage(buttonFound, saveButtonText, url);
     }
 
-    private HtmlPage submitForm(HtmlForm form) throws IOException {
+    private static HtmlPage submitForm(HtmlForm form) throws IOException {
         HtmlPage page;
         if (Jenkins.getVersion().isOlderThan(new VersionNumber("2.320"))) {
             List<HtmlButton> buttons = HtmlUnitHelper.getButtonsByXPath(form, buttonsXPath);
@@ -333,7 +337,7 @@ public class ThrottleQueueTaskDispatcherTest {
         return page;
     }
 
-    private String configureLogger() throws IOException {
+    private static String configureLogger(JenkinsRule r) throws IOException {
         String logger = ThrottleQueueTaskDispatcher.class.getName();
         r.jenkins.getLog().doNewLogRecorder(logger);
         URL url = new URL(r.getURL() + logUrlPrefix + logger + "/" + configUrlSuffix);
@@ -372,7 +376,7 @@ public class ThrottleQueueTaskDispatcherTest {
         return logger;
     }
 
-    private boolean buttonFoundThusFormSubmitted(HtmlForm form, List<HtmlButton> buttons, String buttonText)
+    private static boolean buttonFoundThusFormSubmitted(HtmlForm form, List<HtmlButton> buttons, String buttonText)
             throws IOException {
         boolean buttonFound = false;
         for (HtmlButton button : buttons) {
@@ -385,7 +389,7 @@ public class ThrottleQueueTaskDispatcherTest {
         return buttonFound;
     }
 
-    private String expectedTracesMessage(String traceKind, boolean assertingTrue) {
+    private static String expectedTracesMessage(String traceKind, boolean assertingTrue) {
         StringBuilder messagePrefix = new StringBuilder("log shall");
         if (!assertingTrue) {
             messagePrefix.append(" not");
@@ -393,11 +397,11 @@ public class ThrottleQueueTaskDispatcherTest {
         return messagePrefix + " contain '" + traceKind + "' traces";
     }
 
-    private void failWithMessageIfButtonNotFoundOnPage(boolean buttonFound, String buttonText, URL url) {
-        assertTrue(buttonText + " button not found on " + url, buttonFound);
+    private static void failWithMessageIfButtonNotFoundOnPage(boolean buttonFound, String buttonText, URL url) {
+        assertTrue(buttonFound, buttonText + " button not found on " + url);
     }
 
-    private HtmlPage getLoggerPage(String logger) throws IOException {
+    private static HtmlPage getLoggerPage(JenkinsRule r, String logger) throws IOException {
         URL url = new URL(r.getURL() + logUrlPrefix + logger);
         return r.createWebClient().getPage(url);
     }

--- a/src/test/java/hudson/plugins/throttleconcurrents/testutils/HtmlUnitHelper.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/testutils/HtmlUnitHelper.java
@@ -28,19 +28,16 @@ import java.util.ArrayList;
 import java.util.List;
 import org.htmlunit.html.HtmlButton;
 import org.htmlunit.html.HtmlForm;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Stores helpers for HtmlUnit.
  * @author Oleg Nenashev
  * @since 1.9.0
  */
-@Restricted(NoExternalUse.class)
 public class HtmlUnitHelper {
 
     private HtmlUnitHelper() {
-        // Instantination is prohibited
+        // Instantiation is prohibited
     }
 
     /**


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

There is one exception where a migration was not possible as the tests rely on `Rule` implementations that have not (yet) been migrated to JUnit5:

* `ThrottleJobPropertyPipelineRestartTest` using `JenkinsSessionRule` (in combination with `SemaphoreStep`)


I also took the freedom of re-enabling `ThrottleConcurrentTest` and refactor it to no longer rely on `jgiven`. 
IMHO there is no need for this test in particualar to use it and its better to streamline it with other tests in this plugin.

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub 
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
