### PR TITLE
Fix 'groovyClassPath' test ahead of refined reorderable list

### DIFF
--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcherTest.java
@@ -189,8 +189,7 @@ public class ThrottleQueueTaskDispatcherTest {
         boolean buttonFound = false;
 
         for (HtmlButton button : buttons) {
-            if (button.getTextContent().equals(buttonText)) {
-                buttonFound = true;
+            if (button.asNormalizedText().equals(buttonText)) {
                 button.click();
 
                 HtmlInput input = form.getInputByName("_.categoryName");
@@ -201,9 +200,8 @@ public class ThrottleQueueTaskDispatcherTest {
 
                 buttons = HtmlUnitHelper.getButtonsByXPath(form, parentXPath + buttonsXPath);
                 buttonText = "Add Maximum Per Labeled Node";
-                buttonFound = false;
                 for (HtmlButton deeperButton : buttons) {
-                    if (deeperButton.getTextContent().equals(buttonText)) {
+                    if (deeperButton.asNormalizedText().equals(buttonText)) {
                         buttonFound = true;
                         for (int i = 0; i < numberOfPairs; i++) {
                             List<HtmlInput> inputs;
@@ -344,7 +342,7 @@ public class ThrottleQueueTaskDispatcherTest {
         boolean buttonFound = false;
 
         for (HtmlButton button : buttons) {
-            if (button.getTextContent().equals(buttonText)) {
+            if (button.asNormalizedText().equals(buttonText)) {
                 buttonFound = true;
                 button.click();
 


### PR DESCRIPTION
Fixes the test for https://github.com/jenkinsci/jenkins/pull/10913

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
