### PR TITLE
Ensure maxConcurrentPerNode is honored for declarative pipeline jobs

### DIFF
--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -66,8 +66,17 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     private CauseOfBlockage canTakeImpl(Node node, Task task) {
         final Jenkins jenkins = Jenkins.get();
-        ThrottleJobProperty tjp = getThrottleJobProperty(task);
+
         List<String> pipelineCategories = categoriesForPipeline(task);
+
+        if (task instanceof PlaceholderTask placeholderTask) {
+            // when dealing with a pipeline job, ThrottleJobProperty is defined in the
+            // WorkflowJob wrapped in a PlaceholderTask so update task to ensure correct
+            // throttling of such job
+            task = placeholderTask.getOwnerTask();
+        }
+
+        ThrottleJobProperty tjp = getThrottleJobProperty(task);
 
         // Handle multi-configuration filters
         if (!shouldBeThrottled(task, tjp) && pipelineCategories.isEmpty()) {
@@ -75,10 +84,6 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
 
         if (!pipelineCategories.isEmpty() || (tjp != null && tjp.getThrottleEnabled())) {
-            CauseOfBlockage cause = canRunImpl(task, tjp, pipelineCategories);
-            if (cause != null) {
-                return cause;
-            }
             if (tjp != null) {
                 if (tjp.getThrottleOption().equals("project")) {
                     if (tjp.getMaxConcurrentPerNode() > 0) {
@@ -96,6 +101,10 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 }
             } else if (!pipelineCategories.isEmpty()) {
                 return throttleCheckForCategoriesOnNode(node, jenkins, pipelineCategories);
+            }
+            CauseOfBlockage cause = canRunImpl(task, tjp, pipelineCategories);
+            if (cause != null) {
+                return cause;
             }
         }
 
@@ -577,10 +586,21 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
     private int buildsOnExecutor(Task task, Executor exec) {
         int runCount = 0;
         final Queue.Executable currentExecutable = exec.getCurrentExecutable();
-        if (currentExecutable != null && task.equals(currentExecutable.getParent())) {
-            runCount++;
+        if (currentExecutable != null) {
+            final SubTask executorTask = currentExecutable.getParent();
+            if (task.equals(executorTask)) {
+                runCount++;
+            } else if (executorTask instanceof PlaceholderTask placeholderTask) {
+                // For pipeline executions, project-level throttling may be comparing
+                // either against the PlaceholderTask itself or against the owning
+                // WorkflowJob. Preserve the direct parent-task match above and also
+                // allow the owner task to match here.
+                Queue.Task ownerTask = placeholderTask.getOwnerTask();
+                if (ownerTask != null && task.equals(ownerTask)) {
+                    runCount++;
+                }
+            }
         }
-
         return runCount;
     }
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -49,7 +49,7 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "deliberately mutable")
     public static boolean USE_FLOW_EXECUTION_LIST = Boolean.parseBoolean(
-            System.getProperty(ThrottleQueueTaskDispatcher.class.getName() + ".USE_FLOW_EXECUTION_LIST", "true"));
+            System.getProperty(ThrottleQueueTaskDispatcher.class.getName() + ".USE_FLOW_EXECUTION_LIST", "false"));
 
     @Deprecated
     @Override
@@ -84,6 +84,10 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         }
 
         if (!pipelineCategories.isEmpty() || (tjp != null && tjp.getThrottleEnabled())) {
+            CauseOfBlockage cause = canRunImpl(task, tjp, pipelineCategories);
+            if (cause != null) {
+                return cause;
+            }
             if (tjp != null) {
                 if (tjp.getThrottleOption().equals("project")) {
                     if (tjp.getMaxConcurrentPerNode() > 0) {
@@ -101,10 +105,6 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
                 }
             } else if (!pipelineCategories.isEmpty()) {
                 return throttleCheckForCategoriesOnNode(node, jenkins, pipelineCategories);
-            }
-            CauseOfBlockage cause = canRunImpl(task, tjp, pipelineCategories);
-            if (cause != null) {
-                return cause;
             }
         }
 

--- a/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
+++ b/src/main/java/hudson/plugins/throttleconcurrents/ThrottleQueueTaskDispatcher.java
@@ -560,9 +560,13 @@ public class ThrottleQueueTaskDispatcher extends QueueTaskDispatcher {
         // a build right after it was launched, for some reason.
         Computer computer = node.toComputer();
         if (computer != null) { // Not all nodes are certain to become computers, like nodes with 0 executors.
-            // Count flyweight tasks that might not consume an actual executor.
-            for (Executor e : computer.getOneOffExecutors()) {
-                runCount += buildsOnExecutor(task, e);
+            if (!task.getClass().getName().equals("org.jenkinsci.plugins.workflow.job.WorkflowJob")) {
+                // Count flyweight tasks that might not consume an actual executor, but not for pipeline
+                // jobs as one-off executors are used by the built-in node to track and coordinate
+                // their builds on slave nodes
+                for (Executor e : computer.getOneOffExecutors()) {
+                    runCount += buildsOnExecutor(task, e);
+                }
             }
 
             for (Executor e : computer.getExecutors()) {

--- a/src/test/java/hudson/plugins/throttleconcurrents/TestUtil.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/TestUtil.java
@@ -33,6 +33,8 @@ public class TestUtil {
             new ThrottleJobProperty.ThrottleCategory("two_total", 0, 2, null);
     static final ThrottleJobProperty.ThrottleCategory OTHER_ONE_PER_NODE =
             new ThrottleJobProperty.ThrottleCategory("other_one_per_node", 1, 0, null);
+    static final ThrottleJobProperty.ThrottleCategory TWO_TOTAL_ONE_PER_NODE =
+            new ThrottleJobProperty.ThrottleCategory("two_total_one_per_node", 1, 2, null);
 
     private TestUtil() {
         // Instantiation is prohibited

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineRestartTest.java
@@ -133,7 +133,7 @@ class ThrottleJobPropertyPipelineRestartTest {
             assertNotNull(secondJobFirstRun);
 
             j.jenkins.getQueue().maintain();
-            while (!j.jenkins.getQueue().getBuildableItems().isEmpty()) {
+            while (!(j.jenkins.getQueue().getItems().length == 1)) {
                 Thread.sleep(500);
                 j.jenkins.getQueue().maintain();
             }
@@ -162,7 +162,8 @@ class ThrottleJobPropertyPipelineRestartTest {
             SemaphoreStep.success("wait-first-job/1", null);
             j.assertBuildStatusSuccess(j.waitForCompletion(firstJobFirstRun));
 
-            WorkflowRun thirdJobFirstRun = (WorkflowRun) queuedItem.getFuture().waitForStart();
+            WorkflowRun thirdJobFirstRun =
+                    (WorkflowRun) queuedItem.getFuture().waitForStart().getParentExecutable();
             SemaphoreStep.waitForStart("wait-third-job/1", thirdJobFirstRun);
             j.jenkins.getQueue().maintain();
             assertTrue(j.jenkins.getQueue().isEmpty());

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -23,7 +23,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.jvnet.hudson.test.Issue;
@@ -55,7 +54,6 @@ class ThrottleJobPropertyPipelineTest {
         agents = new ArrayList<>();
     }
 
-    @Disabled("TODO Doesn't work at present")
     @Test
     void onePerNode() throws Exception {
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -362,6 +362,155 @@ class ThrottleJobPropertyPipelineTest {
         j.assertBuildStatusSuccess(j.waitForCompletion(thirdJobFirstRun));
     }
 
+    @Test
+    void twoTotalOnePerNodeForCategory() throws Exception {
+        Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
+        Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
+        TestUtil.setupCategories(TestUtil.TWO_TOTAL_ONE_PER_NODE);
+
+        WorkflowJob firstJob = j.createProject(WorkflowJob.class);
+        firstJob.setDefinition(getJobFlow("first", firstAgent.getNodeName()));
+        firstJob.addProperty(new ThrottleJobProperty(
+                null, // maxConcurrentPerNode
+                null, // maxConcurrentTotal
+                Collections.singletonList(TestUtil.TWO_TOTAL_ONE_PER_NODE.getCategoryName()),
+                true, // throttleEnabled
+                TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
+                false,
+                null,
+                ThrottleMatrixProjectOptions.DEFAULT));
+
+        WorkflowRun firstJobFirstRun = firstJob.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-first-job/1", firstJobFirstRun);
+
+        WorkflowJob secondJob = j.createProject(WorkflowJob.class);
+        secondJob.setDefinition(getJobFlow("second", secondAgent.getNodeName()));
+        secondJob.addProperty(new ThrottleJobProperty(
+                null, // maxConcurrentPerNode
+                null, // maxConcurrentTotal
+                Collections.singletonList(TestUtil.TWO_TOTAL_ONE_PER_NODE.getCategoryName()),
+                true, // throttleEnabled
+                TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
+                false,
+                null,
+                ThrottleMatrixProjectOptions.DEFAULT));
+
+        WorkflowRun secondJobFirstRun = secondJob.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-second-job/1", secondJobFirstRun);
+
+        WorkflowJob thirdJob = j.createProject(WorkflowJob.class);
+        thirdJob.setDefinition(getJobFlow("third", "on-agent"));
+        thirdJob.addProperty(new ThrottleJobProperty(
+                null, // maxConcurrentPerNode
+                null, // maxConcurrentTotal
+                Collections.singletonList(TestUtil.TWO_TOTAL_ONE_PER_NODE.getCategoryName()),
+                true, // throttleEnabled
+                TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
+                false,
+                null,
+                ThrottleMatrixProjectOptions.DEFAULT));
+
+        QueueTaskFuture<WorkflowRun> thirdJobFirstRunFuture = thirdJob.scheduleBuild2(0);
+        j.jenkins.getQueue().maintain();
+        assertFalse(j.jenkins.getQueue().isEmpty());
+        List<Queue.Item> queuedItemList =
+                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
+        assertEquals(1, queuedItemList.size());
+        Queue.Item queuedItem = queuedItemList.get(0);
+        Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
+        assertThat(
+                blockageReasons,
+                hasItem(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(2)
+                        .toString()));
+        assertEquals(1, firstAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(firstAgent, firstJobFirstRun);
+
+        assertEquals(1, secondAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(secondAgent, secondJobFirstRun);
+
+        SemaphoreStep.success("wait-first-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(firstJobFirstRun));
+
+        WorkflowRun thirdJobFirstRun = thirdJobFirstRunFuture.waitForStart();
+        SemaphoreStep.waitForStart("wait-third-job/1", thirdJobFirstRun);
+        j.jenkins.getQueue().maintain();
+        assertTrue(j.jenkins.getQueue().isEmpty());
+        assertEquals(
+                2,
+                firstAgent.toComputer().countBusy() + secondAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(firstAgent, thirdJobFirstRun);
+
+        SemaphoreStep.success("wait-second-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(secondJobFirstRun));
+
+        SemaphoreStep.success("wait-third-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(thirdJobFirstRun));
+    }
+
+    @Test
+    void twoTotalOnePerNodeForProject() throws Exception {
+        Node firstAgent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 4, "on-agent");
+        Node secondAgent = TestUtil.setupAgent(j, secondAgentTmp, agents, null, 4, "on-agent");
+
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(getJobFlow("first", firstAgent.getNodeName()));
+        project.addProperty(new ThrottleJobProperty(
+                1, // maxConcurrentPerNode
+                2, // maxConcurrentTotal
+                Collections.emptyList(),
+                true, // throttleEnabled
+                TestUtil.THROTTLE_OPTION_PROJECT, // throttleOption
+                false,
+                null,
+                ThrottleMatrixProjectOptions.DEFAULT));
+
+        WorkflowRun firstJobFirstRun = project.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-first-job/1", firstJobFirstRun);
+
+        project.setDefinition(getJobFlow("second", secondAgent.getNodeName()));
+
+        WorkflowRun secondJobFirstRun = project.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait-second-job/1", secondJobFirstRun);
+
+        project.setDefinition(getJobFlow("third", "on-agent"));
+
+        QueueTaskFuture<WorkflowRun> thirdJobFirstRunFuture = project.scheduleBuild2(0);
+        j.jenkins.getQueue().maintain();
+        assertFalse(j.jenkins.getQueue().isEmpty());
+        List<Queue.Item> queuedItemList =
+                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
+        assertEquals(1, queuedItemList.size());
+        Queue.Item queuedItem = queuedItemList.get(0);
+        Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
+        assertThat(
+                blockageReasons,
+                hasItem(Messages._ThrottleQueueTaskDispatcher_MaxCapacityTotal(2)
+                        .toString()));
+        assertEquals(1, firstAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(firstAgent, firstJobFirstRun);
+
+        assertEquals(1, secondAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(secondAgent, secondJobFirstRun);
+
+        SemaphoreStep.success("wait-first-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(firstJobFirstRun));
+
+        WorkflowRun thirdJobFirstRun = thirdJobFirstRunFuture.waitForStart();
+        SemaphoreStep.waitForStart("wait-third-job/1", thirdJobFirstRun);
+        j.jenkins.getQueue().maintain();
+        assertTrue(j.jenkins.getQueue().isEmpty());
+        assertEquals(
+                2,
+                firstAgent.toComputer().countBusy() + secondAgent.toComputer().countBusy());
+        TestUtil.hasPlaceholderTaskForRun(firstAgent, thirdJobFirstRun);
+
+        SemaphoreStep.success("wait-second-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(secondJobFirstRun));
+
+        SemaphoreStep.success("wait-third-job/1", null);
+        j.assertBuildStatusSuccess(j.waitForCompletion(thirdJobFirstRun));
+    }
+
     @Issue("JENKINS-37809")
     @Test
     void limitOneJobWithMatchingParams() throws Exception {

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -56,62 +57,119 @@ class ThrottleJobPropertyPipelineTest {
 
     @Test
     void onePerNode() throws Exception {
+
+        Jenkins.get().setLabelString("built-in");
+        Jenkins.get().save();
+
         Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");
         TestUtil.setupCategories(TestUtil.ONE_PER_NODE);
 
-        WorkflowJob firstJob = j.createProject(WorkflowJob.class);
-        firstJob.setDefinition(getJobFlow("first", agent.getNodeName()));
-        firstJob.addProperty(new ThrottleJobProperty(
-                null, // maxConcurrentPerNode
-                null, // maxConcurrentTotal
-                Collections.singletonList(TestUtil.ONE_PER_NODE.getCategoryName()),
-                true, // throttleEnabled
-                TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
-                false,
-                null,
-                ThrottleMatrixProjectOptions.DEFAULT));
+        // two jobs will be created on the slave node and on the built-in node
+        Node[] nodes = {agent, Jenkins.get()};
 
-        WorkflowRun firstJobFirstRun = firstJob.scheduleBuild2(0).waitForStart();
-        SemaphoreStep.waitForStart("wait-first-job/1", firstJobFirstRun);
+        ArrayList<ArrayList<WorkflowRun>> jobsRuns = new ArrayList<ArrayList<WorkflowRun>>();
 
-        WorkflowJob secondJob = j.createProject(WorkflowJob.class);
-        secondJob.setDefinition(getJobFlow("second", agent.getNodeName()));
-        secondJob.addProperty(new ThrottleJobProperty(
-                null, // maxConcurrentPerNode
-                null, // maxConcurrentTotal
-                Collections.singletonList(TestUtil.ONE_PER_NODE.getCategoryName()),
-                true, // throttleEnabled
-                TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
-                false,
-                null,
-                ThrottleMatrixProjectOptions.DEFAULT));
+        int expectedQueueSize = 1;
 
-        WorkflowRun secondJobFirstRun = secondJob.scheduleBuild2(0).waitForStart();
-        j.waitForMessage("Still waiting to schedule task", secondJobFirstRun);
-        j.jenkins.getQueue().maintain();
-        assertFalse(j.jenkins.getQueue().isEmpty());
+        // create two jobs per node
+        for (Node node : nodes) {
+            ArrayList<WorkflowRun> jobRuns = new ArrayList<WorkflowRun>();
 
-        List<Queue.Item> queuedItemList =
-                Arrays.stream(j.jenkins.getQueue().getItems()).toList();
-        assertEquals(1, queuedItemList.size());
-        Queue.Item queuedItem = queuedItemList.get(0);
-        Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
-        assertThat(
-                blockageReasons,
-                hasItem(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(1)
-                        .toString()));
-        assertEquals(1, agent.toComputer().countBusy());
-        TestUtil.hasPlaceholderTaskForRun(agent, firstJobFirstRun);
+            // create first job
+            WorkflowJob firstJob = j.createProject(WorkflowJob.class);
+            firstJob.setDefinition(getJobFlow("first" + node.getLabelString(), node.getLabelString()));
+            firstJob.addProperty(new ThrottleJobProperty(
+                    null, // maxConcurrentPerNode
+                    null, // maxConcurrentTotal
+                    Collections.singletonList(TestUtil.ONE_PER_NODE.getCategoryName()),
+                    true, // throttleEnabled
+                    TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
+                    false,
+                    null,
+                    ThrottleMatrixProjectOptions.DEFAULT));
 
-        SemaphoreStep.success("wait-first-job/1", null);
-        j.assertBuildStatusSuccess(j.waitForCompletion(firstJobFirstRun));
-        SemaphoreStep.waitForStart("wait-second-job/1", secondJobFirstRun);
-        j.jenkins.getQueue().maintain();
-        assertTrue(j.jenkins.getQueue().isEmpty());
-        assertEquals(1, agent.toComputer().countBusy());
-        TestUtil.hasPlaceholderTaskForRun(agent, secondJobFirstRun);
-        SemaphoreStep.success("wait-second-job/1", null);
-        j.assertBuildStatusSuccess(j.waitForCompletion(secondJobFirstRun));
+            // start first job
+            WorkflowRun firstJobFirstRun = firstJob.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait-first" + node.getLabelString() + "-job/1", firstJobFirstRun);
+
+            // create second job
+            WorkflowJob secondJob = j.createProject(WorkflowJob.class);
+            secondJob.setDefinition(getJobFlow("second" + node.getLabelString(), node.getLabelString()));
+            secondJob.addProperty(new ThrottleJobProperty(
+                    null, // maxConcurrentPerNode
+                    null, // maxConcurrentTotal
+                    Collections.singletonList(TestUtil.ONE_PER_NODE.getCategoryName()),
+                    true, // throttleEnabled
+                    TestUtil.THROTTLE_OPTION_CATEGORY, // throttleOption
+                    false,
+                    null,
+                    ThrottleMatrixProjectOptions.DEFAULT));
+
+            // start second job
+            WorkflowRun secondJobFirstRun = secondJob.scheduleBuild2(0).waitForStart();
+            j.waitForMessage("Still waiting to schedule task", secondJobFirstRun);
+            j.jenkins.getQueue().maintain();
+
+            // second job should be blocked as it is at most one running job per node
+            assertFalse(j.jenkins.getQueue().isEmpty());
+            List<Queue.Item> queuedItemList =
+                    Arrays.stream(j.jenkins.getQueue().getItems()).toList();
+            // queue size should be 1 after creating jobs on first node and 2 after
+            // creating jobs on second node
+            assertEquals(expectedQueueSize++, queuedItemList.size());
+
+            // check jobs are blocked because another job is already running on associated node
+            for (Queue.Item queuedItem : queuedItemList) {
+                Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
+                assertThat(
+                        blockageReasons,
+                        hasItem(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(1)
+                                .toString()));
+            }
+
+            // first job should be running
+            assertEquals(1, node.toComputer().countBusy());
+            TestUtil.hasPlaceholderTaskForRun(node, firstJobFirstRun);
+
+            jobRuns.add(firstJobFirstRun);
+            jobRuns.add(secondJobFirstRun);
+            jobsRuns.add(jobRuns);
+        }
+
+        // terminate first job on each node, check second one can start afterwards
+        for (int i = 0; i < nodes.length; ++i) {
+            Node node = nodes[i];
+            WorkflowRun firstJobFirstRun = jobsRuns.get(i).get(0);
+            WorkflowRun secondJobFirstRun = jobsRuns.get(i).get(1);
+
+            // terminate first job
+            SemaphoreStep.success("wait-first" + node.getLabelString() + "-job/1", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(firstJobFirstRun));
+            SemaphoreStep.waitForStart("wait-second" + node.getLabelString() + "-job/1", secondJobFirstRun);
+            j.jenkins.getQueue().maintain();
+
+            if (i == 0) {
+                // after terminating first job on first node,
+                // second job on second node should still be in the queue
+                assertFalse(j.jenkins.getQueue().isEmpty());
+
+            } else {
+                // after terminating first job on second node,
+                // second job on second node should no longer be in the queue
+                assertTrue(j.jenkins.getQueue().isEmpty());
+            }
+
+            // second job should be running
+            assertEquals(1, node.toComputer().countBusy());
+            TestUtil.hasPlaceholderTaskForRun(node, secondJobFirstRun);
+
+            // terminate second job
+            SemaphoreStep.success("wait-second" + node.getLabelString() + "-job/1", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(secondJobFirstRun));
+
+            // no more jobs should be running on the node
+            assertEquals(0, node.toComputer().countBusy());
+        }
     }
 
     @Test

--- a/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
+++ b/src/test/java/hudson/plugins/throttleconcurrents/ThrottleJobPropertyPipelineTest.java
@@ -56,7 +56,112 @@ class ThrottleJobPropertyPipelineTest {
     }
 
     @Test
-    void onePerNode() throws Exception {
+    void onePerNodeForProject() throws Exception {
+
+        Jenkins.get().setLabelString("built-in");
+        Jenkins.get().save();
+
+        Node agent = TestUtil.setupAgent(j, firstAgentTmp, agents, null, 2, "on-agent");
+
+        // two jobs will be created on the slave node and on the built-in node
+        Node[] nodes = {agent, Jenkins.get()};
+
+        ArrayList<ArrayList<WorkflowRun>> jobsRuns = new ArrayList<ArrayList<WorkflowRun>>();
+
+        int expectedQueueSize = 1;
+
+        // create pipeline project
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.addProperty(new ThrottleJobProperty(
+                1, // maxConcurrentPerNode
+                0, // maxConcurrentTotal
+                Collections.emptyList(),
+                true, // throttleEnabled
+                TestUtil.THROTTLE_OPTION_PROJECT, // throttleOption
+                false,
+                null,
+                ThrottleMatrixProjectOptions.DEFAULT));
+
+        // create two jobs per node
+        for (Node node : nodes) {
+            ArrayList<WorkflowRun> jobRuns = new ArrayList<WorkflowRun>();
+
+            // ensure job run only on node
+            project.setDefinition(getJobFlow(node.getLabelString(), node.getLabelString()));
+
+            // start first job
+            WorkflowRun jobFirstRun = project.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait-" + node.getLabelString() + "-job/1", jobFirstRun);
+
+            // start second job
+            WorkflowRun jobSecondRun = project.scheduleBuild2(0).waitForStart();
+            j.waitForMessage("Still waiting to schedule task", jobSecondRun);
+            j.jenkins.getQueue().maintain();
+
+            // second job should be blocked as it is at most one running job per node
+            assertFalse(j.jenkins.getQueue().isEmpty());
+            List<Queue.Item> queuedItemList =
+                    Arrays.stream(j.jenkins.getQueue().getItems()).toList();
+            // queue size should be 1 after creating jobs on first node and 2 after
+            // creating jobs on second node
+            assertEquals(expectedQueueSize++, queuedItemList.size());
+
+            // check jobs are blocked because another job is already running on associated node
+            for (Queue.Item queuedItem : queuedItemList) {
+                Set<String> blockageReasons = TestUtil.getBlockageReasons(queuedItem.getCauseOfBlockage());
+                assertThat(
+                        blockageReasons,
+                        hasItem(Messages._ThrottleQueueTaskDispatcher_MaxCapacityOnNode(1)
+                                .toString()));
+            }
+
+            // first job should be running
+            assertEquals(1, node.toComputer().countBusy());
+            TestUtil.hasPlaceholderTaskForRun(node, jobFirstRun);
+
+            jobRuns.add(jobFirstRun);
+            jobRuns.add(jobSecondRun);
+            jobsRuns.add(jobRuns);
+        }
+
+        // terminate first job on each node, check second one can start afterwards
+        for (int i = 0; i < nodes.length; ++i) {
+            Node node = nodes[i];
+            WorkflowRun jobFirstRun = jobsRuns.get(i).get(0);
+            WorkflowRun jobSecondRun = jobsRuns.get(i).get(1);
+
+            // terminate first job
+            SemaphoreStep.success("wait-" + node.getLabelString() + "-job/1", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(jobFirstRun));
+            SemaphoreStep.waitForStart("wait-" + node.getLabelString() + "-job/2", jobSecondRun);
+            j.jenkins.getQueue().maintain();
+
+            if (i == 0) {
+                // after terminating first job on first node,
+                // second job on second node should still be in the queue
+                assertFalse(j.jenkins.getQueue().isEmpty());
+
+            } else {
+                // after terminating first job on second node,
+                // second job on second node should no longer be in the queue
+                assertTrue(j.jenkins.getQueue().isEmpty());
+            }
+
+            // second job should be running
+            assertEquals(1, node.toComputer().countBusy());
+            TestUtil.hasPlaceholderTaskForRun(node, jobSecondRun);
+
+            // terminate second job
+            SemaphoreStep.success("wait-" + node.getLabelString() + "-job/2", null);
+            j.assertBuildStatusSuccess(j.waitForCompletion(jobSecondRun));
+
+            // no more jobs should be running on the node
+            assertEquals(0, node.toComputer().countBusy());
+        }
+    }
+
+    @Test
+    void onePerNodeForCategory() throws Exception {
 
         Jenkins.get().setLabelString("built-in");
         Jenkins.get().save();


### PR DESCRIPTION
I noticed that `maxConcurrentPerNode` parameter was not honored for declarative pipeline jobs and discovered that it was a known issue (#413 and #446).

Fixes #413 
Fixes #446 

I would like that feature to work as most of the jobs on our Jenkins instance are pipeline jobs. So I took some time to debug the issue and found a fix ensuring that parameter is now honored on all slave nodes, throttling issues still remain on the built-in node, see commit message below.

----

Due to `WorkflowJob` instance being wrapped in a `PlaceHolderTask` instance when `ThrottleQueueTaskDispatcher.canTake` is called, the computed run count for a declarative pipeline job was always equal to 0 as the wrong task was used to compare with those running on node executors.

The changes in this commit ensures that `maxConcurrentPerNode` is now honored on all slave nodes.

Regarding the built-in (or master) node, throttling issues remain as flyweight tasks running on it are considered when counting job runs, but flyweight tasks on master node are used to track and coordinate pipeline builds running on slave nodes so jobs running on slaves are counted as running on master.

---

All tests are still passing and the remaining failing one related to that issue now succeeds.

---

**Update:** I also added a commit that fixes the remaining per node throttling issue for pipeline jobs on the built-in node when slave nodes are also available.

---

**Update (16/06/2026):** @gandadil and I did more testing which made us discover that the total run count computation on all nodes for pipeline jobs was not correct, leading to other scheduling issues. I fixed that in e6117cb and added new related tests.